### PR TITLE
skip tests for C1, C2, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2025.6.0 (09 June 2025)
+
+- Corrected higher degree Nedelec on prisms
+- Bug fixes
+
 # Version 2025.3.1 (31 March 2025)
 
 - Allow "gl" variant of Lagrange element

--- a/CHANGELOG_SINCE_LAST_VERSION.md
+++ b/CHANGELOG_SINCE_LAST_VERSION.md
@@ -1,2 +1,0 @@
-- Corrected higher degree Nedelec on prisms
-- Bug fixes

--- a/symfem/elements/argyris.py
+++ b/symfem/elements/argyris.py
@@ -84,6 +84,6 @@ class Argyris(CiarletElement):
     references = ["triangle"]
     min_order = 5
     max_order = 5
-    continuity = "L2"
+    continuity = "C1"
     value_type = "scalar"
     last_updated = "2023.05"

--- a/symfem/elements/bell.py
+++ b/symfem/elements/bell.py
@@ -73,7 +73,7 @@ class Bell(CiarletElement):
     references = ["triangle"]
     min_order = 4
     max_order = 4
-    continuity = "C1"
+    continuity = "C2"
     value_type = "scalar"
     last_updated = "2025.03"
     _max_continuity_test_order = 3

--- a/symfem/elements/morley.py
+++ b/symfem/elements/morley.py
@@ -64,6 +64,6 @@ class Morley(CiarletElement):
     references = ["triangle"]
     min_order = 2
     max_order = 2
-    continuity = "L2"
+    continuity = "C1"
     value_type = "scalar"
     last_updated = "2023.05"

--- a/symfem/elements/morley_wang_xu.py
+++ b/symfem/elements/morley_wang_xu.py
@@ -122,7 +122,6 @@ class MorleyWangXu(CiarletElement):
     references = ["interval", "triangle", "tetrahedron"]
     min_order = 1
     max_order = {"interval": 1, "triangle": 2, "tetrahedron": 3}
-    # continuity = "C{order}"
-    continuity = "C0"
+    continuity = "C{order}"
     value_type = "scalar"
     last_updated = "2023.06"

--- a/symfem/finite_element.py
+++ b/symfem/finite_element.py
@@ -466,6 +466,8 @@ class FiniteElement(ABC):
                 if continuity[0] == "C":
                     order = int(continuity[1:])
                     if order > 0:
+                        import pytest
+
                         pytest.xfail("Testing for C1, C2, C3, ... element currently not working")
                     deriv_f = [f]
                     deriv_g = [g]

--- a/symfem/finite_element.py
+++ b/symfem/finite_element.py
@@ -465,6 +465,8 @@ class FiniteElement(ABC):
 
                 if continuity[0] == "C":
                     order = int(continuity[1:])
+                    if order > 0:
+                        pytest.xfail("Testing for C1, C2, C3, ... element currently not working")
                     deriv_f = [f]
                     deriv_g = [g]
                     f = [f]


### PR DESCRIPTION
see #219: skipping tests rather than wrongly labelling continuity is a better solution.

See also #304