### PR TITLE
Only use $^\prime$ notation for single derivative

### DIFF
--- a/symfem/functionals.py
+++ b/symfem/functionals.py
@@ -454,7 +454,7 @@ class DerivativePointEvaluation(BaseFunctional):
             Representation of the functional as TeX, and list of terms involved
         """
         assert isinstance(self.point, VectorFunction)
-        if len(self.point) == 1:
+        if len(self.point) == 1 and self.derivative[0] == 1:
             desc = "v\\mapsto "
             desc += f"v'({','.join([_to_tex(i, True) for i in self.point])})"
             return desc, []


### PR DESCRIPTION
For the Taylor element at DefElement, all the high-order DOFs are [shown](https://defelement.org/elements/examples/interval-taylor-3.html) as, e.g.,
$$\displaystyle l_{3}:v\mapsto v'(\tfrac{1}{2}).$$
That is, any `DerivativePointEvaluation` in one dimension is rendered as a first derivative, regardless of the actual order.

This PR simply falls back to the Leibniz notation branch, but I could further extend the Lagrange notation (up to three primes, $v^{(n)}$ for $n > 3$) if desired.

Output difference from running `python -m pytest test\test_dof_descriptions.py -s --verbose`:
```diff
$ diff -u before.log after.log
--- before.log  2025-08-14 20:12:52.331668100 -0700
+++ after.log   2025-08-14 20:14:54.667755700 -0700
@@ -243,18 +243,18 @@
 PASSED
 test/test_dof_descriptions.py::test_element[interval-Taylor-2-kwargs62] v\mapsto\displaystyle\int_{R}v
 v\mapsto v'(\tfrac{1}{2})
-v\mapsto v'(\tfrac{1}{2})
+v\mapsto\frac{\partial^{2}}{\partial x^{2}}v(\tfrac{1}{2})
 PASSED
 test/test_dof_descriptions.py::test_element[interval-Taylor-3-kwargs63] v\mapsto\displaystyle\int_{R}v
 v\mapsto v'(\tfrac{1}{2})
-v\mapsto v'(\tfrac{1}{2})
-v\mapsto v'(\tfrac{1}{2})
+v\mapsto\frac{\partial^{2}}{\partial x^{2}}v(\tfrac{1}{2})
+v\mapsto\frac{\partial^{3}}{\partial x^{3}}v(\tfrac{1}{2})
 PASSED
 test/test_dof_descriptions.py::test_element[interval-Taylor-4-kwargs64] v\mapsto\displaystyle\int_{R}v
 v\mapsto v'(\tfrac{1}{2})
-v\mapsto v'(\tfrac{1}{2})
-v\mapsto v'(\tfrac{1}{2})
-v\mapsto v'(\tfrac{1}{2})
+v\mapsto\frac{\partial^{2}}{\partial x^{2}}v(\tfrac{1}{2})
+v\mapsto\frac{\partial^{3}}{\partial x^{3}}v(\tfrac{1}{2})
+v\mapsto\frac{\partial^{4}}{\partial x^{4}}v(\tfrac{1}{2})
 PASSED
 test/test_dof_descriptions.py::test_element[interval-Wu-Xu-3-kwargs65] v\mapsto v(0)
 v\mapsto v'(0)
@@ -5611,4 +5611,4 @@
 v\mapsto v(\tfrac{1}{3},\tfrac{1}{3},\tfrac{1}{3})
 PASSED

-======================= 450 passed in 71.59s (0:01:11) ========================
+======================= 450 passed in 77.73s (0:01:17) ========================
```