### PR TITLE
Update tnt.py

### DIFF
--- a/symfem/elements/dpc.py
+++ b/symfem/elements/dpc.py
@@ -88,11 +88,11 @@ class DPC(CiarletElement):
         return self.order
 
     names = ["dPc"]
-    references = ["interval", "quadrilateral", "hexahedron"]
+    references = ["interval", "triangle", "quadrilateral", "tetrahedron", "hexahedron", "prism", "pyramid"] # don't know what the use is for prism. Pyramid according to Cockburn & Fu
     min_order = 0
     continuity = "L2"
     value_type = "scalar"
-    last_updated = "2023.07.1"
+    last_updated = "2026.1"
 
 
 class VectorDPC(CiarletElement):

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -230,9 +230,28 @@ class TNTcurl(CiarletElement):
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        if reference.name in ["interval", "triangle", "tetrahedron"]:
+        if reference.name in ["interval", "triangle", "tetrahedron", "pyramid"]:
             poly += polynomial_set_vector(reference.tdim, reference.tdim, order-1)
             poly += Hcurl_polynomials(reference.tdim,reference.tdim,order)
+            if reference.name == "pyramid":
+                pol=pyramid_polynomial_set_1d(3, order)
+                print(pol)
+                for ii in range(order-1):
+                    poly.append(ScalarFunction(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]).grad(3))
+                poly.append(ScalarFunction(pol[2*order+1]).grad(3))
+                if order>1:
+                    for ii in range(order-2):
+                        poly.append(ScalarFunction(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]).grad(3))
+                        for jj in range(ii+1):
+                            poly.append(ScalarFunction(pol[3*order+1+ii*order+jj]).grad(3))
+                    poly.append(ScalarFunction(pol[order*(order+1)+1]).grad(3))
+                pol=polynomial_set_vector(3,3,0)
+                for pl in pol[max(4-2*order,0):]:
+                    poly.append(x[0]*x[1]/(1-x[2])*pl) # modified from Cockburn & Fu
+                pol=pyramid_polynomial_set_1d(3,order-1)
+                for ii in range(order-1):
+                    for jj in range(ii+1):
+                        poly.append(VectorFunction([x[1],-x[0],0])*pol[ii+1+(jj+1)*(order+1)]) 
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
@@ -283,20 +302,13 @@ class TNTcurl(CiarletElement):
                 poly.append(VectorFunction([x[1],-x[0],0])*x[0]**i*x[1]**(order-i-1))
                 poly.append(VectorFunction([x[1],-x[0],0])*x[0]**i*x[1]**(order-i-1)*x[2])
             for i in range(order+1):  
-                poly.append(VectorFunction([0,0,x[0]**i*x[1]**(order-i)]).curl().cross(VectorFunction([x[0],x[1],x[2]]))*x[2]**(order-1))
+                poly.append(VectorFunction([0,0,x[0]**i*x[1]**(order-i)]).curl().cross(VectorFunction([x[0],x[1],x[2]]))*x[2]**(order-1))  # modified from Cockburn & Fu
                 poly.append(ScalarFunction(x[0]**i*x[1]**(order-i)*x[2]).grad(3)) # P~_order(x[0],x[1])*x[2]
             if order > 1:
-                # P_1(x[0],x[1])*x[2]**order
-                for pl in polynomial_set_1d(2, 1)[1:]:
-                    poly.append(ScalarFunction(x[2]**order*pl).grad(3))
+                for pl in polynomial_set_1d(2, 1)[1:]:  
+                    poly.append(ScalarFunction(x[2]**order*pl).grad(3))  # P_1(x[0],x[1])*x[2]**order
                 poly.append(VectorFunction([x[1],-x[0],0])*x[2]**order)
             print(reference.name,order,poly)
-            
-                    
-        elif reference.name == "pyramid":
-            None
-
-            poly += prism_polynomial_set_1d(3, order - 1)
                     
         dofs: ListOfFunctionals = []
         dofs += make_integral_moment_dofs(reference, edges=(TangentIntegralMoment, Q, order - 1, {"variant": variant}))
@@ -337,7 +349,7 @@ class TNTcurl(CiarletElement):
                 dofs.append(IntegralAgainst(reference, f[0], entity=(2, f[1]), mapping="covariant"))
         elif reference.name == "pyramid":
             for f in face_moments_q:
-                dofs.append(IntegralAgainst(reference, entity=(2, f), mapping="covariant"))
+                dofs.append(IntegralAgainst(reference, f[0], entity=(2, 0), mapping="covariant"))
             for f in product(face_moments_s, range(1,5)):
                 dofs.append(IntegralAgainst(reference, f[0], entity=(2, f[1]), mapping="covariant"))
             

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -1,7 +1,7 @@
 """TiNiest Tensor product (TNT) elements.
 
 These elements' definitions appear in https://doi.org/10.1090/S0025-5718-2013-02729-9
-(Cockburn, Qiu, 2013)
+(Cockburn, Qiu, 2013) and https://doi.org/10.1137/16M1073352 (Cockburn, Fu, 2017)
 """
 
 import typing
@@ -21,7 +21,7 @@ from symfem.functionals import (
 )
 from symfem.functions import FunctionInput, ScalarFunction, VectorFunction
 from symfem.moments import make_integral_moment_dofs
-from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector
+from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector, polynomial_set_1d, prism_polynomial_set_1d, pyramid_polynomial_set_1d
 from symfem.references import NonDefaultReferenceError, Reference
 from symfem.symbols import t, x
 
@@ -55,7 +55,7 @@ def b(k: int, v: sympy.core.symbol.Symbol) -> ScalarFunction:
         The function B_k
     """
     if k == 1:
-        return ScalarFunction(0)
+        return p(k, v) / (4 + k - 2)
     return (p(k, v) - p(k - 2, v)) / (4 + k - 2)
 
 
@@ -64,6 +64,7 @@ class TNT(CiarletElement):
 
     def __init__(self, reference: Reference, order: int, variant: str = "equispaced"):
         """Create the element.
+                f = sympy.Integer(1)
 
         Args:
             reference: The reference element
@@ -74,49 +75,115 @@ class TNT(CiarletElement):
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        poly += quolynomial_set_1d(reference.tdim, order - 1)
-        if reference.tdim == 2:
-            for i in range(2):
-                variables = [x[j] for j in range(2) if j != i]
-                for f in [1 - variables[0], variables[0]]:
-                    poly.append(f * b(order, x[i]))
-
-        elif reference.tdim == 3:
-            for i in range(3):
-                variables = [x[j] for j in range(3) if j != i]
-                for f0 in [1 - variables[0], variables[0]]:
-                    for f1 in [1 - variables[1], variables[1]]:
-                        poly.append(f0 * f1 * b(order, x[i]))
+        if reference.name == "interval" or reference.name == "triangle" or reference.name == "tetrahedron":
+            poly += polynomial_set_1d(reference.tdim, order)
+        elif reference.name == "quadrilateral" or reference.name == "hexahedron":
+            poly += quolynomial_set_1d(reference.tdim, order - 1)
+            if reference.tdim == 2:
+                for i in range(2):
+                    variables = [x[j] for j in range(2) if j != i]
+                    if i==1 or order!=1:
+                        for f in [1 - variables[0], variables[0]]:
+                            poly.append(f * b(order, x[i]))
+                    else:
+                        poly.append(variables[0] * b(order, x[i]))
+            elif reference.tdim == 3:
+                for i in range(3):
+                    variables = [x[(i+j+1) % 3] for j in range(2)]
+                    for f0 in [1 - variables[0], variables[0]]:
+                        if order!=1 or (i==1 and f0==1-variables[0]):
+                            for f1 in [1 - variables[1], variables[1]]:
+                                poly.append(f0 * f1 * b(order, x[i]))
+                        else:
+                            poly.append(f0 * variables[1] * b(order, x[i]))
+        elif reference.name == "prism":
+            poly += prism_polynomial_set_1d(3, order - 1)
+            pol=polynomial_set_1d(2, 1)  # P_1(x[0],x[1])*x[2]**order
+            for ii in range(len(pol)):
+                poly.append(x[2]**order*pol[ii])
+            for i in range(order+1):  # P~_order(x[0],x[1])*{1,x[2]}
+                poly.append(x[0]**i*x[1]**(order-i))
+                if order>1:
+                    poly.append(x[0]**i*x[1]**(order-i)*x[2])
+        elif reference.name == "pyramid":
+            poly+=polynomial_set_1d(3,order)
+            pol=pyramid_polynomial_set_1d(3, order)
+            for ii in range(order-1):
+                poly.append(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)])
+            poly.append(pol[2*order+1])
+            if order>1:
+                for ii in range(order-2):
+                    poly.append(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)])
+                    for jj in range(ii+1):
+                        poly.append(pol[3*order+1+ii*order+jj])
+                poly.append(pol[order*(order+1)+1])
 
         dofs: ListOfFunctionals = []
         for i, v in enumerate(reference.vertices):
             dofs.append(PointEvaluation(reference, v, entity=(0, i)))
 
-        for i in range(1, order):
-            f = i * t[0] ** (i - 1)
-            for edge_n in range(reference.sub_entity_count(1)):
-                dofs.append(IntegralAgainst(reference, f, entity=(1, edge_n), mapping="identity"))
+        pol=polynomial_set_1d(1, order-1)
+        for edge_n,ii in product(range(reference.sub_entity_count(1)),range(1,order)): # skip 0th order as it falls in the kernel of the gradient
+                dofs.append(IntegralAgainst(reference, pol[ii].grad(1)[0], entity=(1, edge_n), mapping="identity")) 
 
-        for i in range(1, order - 1):
-            for j in range(1, order - 1):
-                f = t[0] ** i * (t[0] - 1) * t[1] ** j * (t[1] - 1)
-                delta_f = (f.diff(t[0]).diff(t[0]) + f.diff(t[1]).diff(t[1])).expand()
-                for face_n in range(reference.sub_entity_count(2)):
-                    dofs.append(
-                        IntegralAgainst(reference, delta_f, entity=(2, face_n), mapping="identity")
-                    )
-
-        if reference.tdim == 3:
-            dummy_dof = PointEvaluation(reference, reference.midpoint(), (3, 0))
-            for ii in product(range(1, order - 1), repeat=3):
-                f = sympy.Integer(1)
-                for j, k in zip(ii, x):
-                    f *= k**j * (k - 1)
-                grad_f = tuple(sympy.S(j).expand() for j in ScalarFunction(f).grad(3))
+        if reference.name == "triangle" or reference.name == "tetrahedron":
+            pol=polynomial_set_1d(2, order-3)
+            for face_n,ii in product(range(reference.sub_entity_count(2)),range(len(pol))):
                 dofs.append(
-                    DerivativeIntegralMoment(
-                        reference, 1, grad_f, dummy_dof, entity=(3, 0), mapping="identity"
-                    )
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity")
+                )
+        elif reference.name == "quadrilateral" or reference.name =="hexahedron":
+            pol=quolynomial_set_1d(2, order-3)
+            for face_n,ii in product(range(reference.sub_entity_count(2)),range(len(pol))):
+                dofs.append(
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity")
+                ) 
+        elif reference.name == "prism":
+            pol=polynomial_set_1d(2, order-3)
+            for face_n,ii in product([0,4],range(len(pol))):
+                dofs.append(
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
+                )
+            pol=quolynomial_set_1d(2, order-3)
+            for face_n,ii in product(range(1,4),range(len(pol))):
+                dofs.append(
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity")
+                ) 
+        elif reference.name == "pyramid":
+            pol=quolynomial_set_1d(2, order-3)
+            for ii in range(len(pol)):
+                dofs.append(
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pol[ii]).grad(2)), entity=(2, 0), mapping="identity")
+                ) 
+            pol=polynomial_set_1d(2, order-3)
+            for face_n,ii in product(range(1,5),range(len(pol))):
+                dofs.append(
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
+                )
+                    
+        if reference.name == "tetrahedron":
+            pol=polynomial_set_1d(3, order-4)
+            for ii in range(len(pol)):
+                dofs.append(
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[1]-x[2])*pol[ii]).grad(3)),entity=(3, 0), mapping="identity")
+                )
+        elif reference.name == "hexahedron":
+            pol=quolynomial_set_1d(3, order-3)
+            for ii in range(len(pol)):
+                dofs.append(
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*pol[ii]).grad(3)),entity=(3, 0), mapping="identity")
+                )
+        elif reference.name == "prism":
+            pol=prism_polynomial_set_1d(3, order-3)
+            for i,j in product(range((order - 2) * (order - 3)// 2),range(order - 2)): # no upper xy power
+                dofs.append(
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*pol[i+j*(order-1)*(order-2)//2]).grad(3)),entity=(3, 0), mapping="identity")
+                )
+        elif reference.name == "pyramid":
+            pol=polynomial_set_1d(3, order-5)
+            for ii in range(len(pol)):
+                dofs.append(
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pol[ii]).grad(3)),entity=(3, 0), mapping="identity")
                 )
 
         super().__init__(reference, order, poly, dofs, reference.tdim, 1)
@@ -132,7 +199,10 @@ class TNT(CiarletElement):
 
     @property
     def lagrange_subdegree(self) -> int:
-        return self.order - 1
+        if reference.name == "interval" or reference.name == "triangle" or reference.name == "tetrahedron":
+            return self.order
+        else:
+            return self.order - 1
 
     @property
     def lagrange_superdegree(self) -> int | None:
@@ -144,11 +214,14 @@ class TNT(CiarletElement):
 
     @property
     def polynomial_superdegree(self) -> int | None:
-        return max((self.order - 1) * self.reference.tdim, (self.order - 1) + self.reference.tdim)
+        if reference.name == "interval" or reference.name == "triangle" or reference.name == "tetrahedron":
+            return self.order
+        else:
+            return max((self.order - 1) * self.reference.tdim, (self.order - 1) + self.reference.tdim)
 
     names = ["tiniest tensor", "TNT"]
-    references = ["quadrilateral", "hexahedron"]
-    min_order = 2
+    references = ["interval", "triangle", "tetrahedron", "quadrilateral", "hexahedron", "prism", "pyramid"]
+    min_order = 1
     continuity = "C0"
     value_type = "scalar"
     last_updated = "2025.03"
@@ -489,7 +562,43 @@ class TNTdiv(CiarletElement):
         return self.order + 1
 
     @property
-    def polynomial_subdegree(self) -> int:
+    def polynomial_subdegree(self) -> int:"""TiNiest Tensor product (TNT) elements.
+
+These elements' definitions appear in https://doi.org/10.1090/S0025-5718-2013-02729-9
+(Cockburn, Qiu, 2013)
+"""
+
+import typing
+from itertools import product
+
+import sympy
+
+from symfem.elements.q import Q
+from symfem.finite_element import CiarletElement
+from symfem.functionals import (
+    DerivativeIntegralMoment,
+    IntegralAgainst,
+    ListOfFunctionals,
+    NormalIntegralMoment,
+    PointEvaluation,
+    TangentIntegralMoment,
+)
+from symfem.functions import FunctionInput, ScalarFunction, VectorFunction
+from symfem.moments import make_integral_moment_dofs
+from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector
+from symfem.references import NonDefaultReferenceError, Reference
+from symfem.symbols import t, x
+
+__all__ = ["p", "b", "TNT", "TNTcurl", "TNTdiv"]
+
+
+def p(k: int, v: sympy.core.symbol.Symbol) -> ScalarFunction:
+    """Return the kth Legendre polynomial.
+
+    Args:
+        k: k
+        v: The variable to use
+
         return self.order
 
     @property

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -12,7 +12,6 @@ import sympy
 from symfem.elements.q import Q
 from symfem.finite_element import CiarletElement
 from symfem.functionals import (
-    DerivativeIntegralMoment,
     IntegralAgainst,
     ListOfFunctionals,
     NormalIntegralMoment,
@@ -74,9 +73,20 @@ class TNT(CiarletElement):
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        if reference.name == "interval" or reference.name == "triangle" or reference.name == "tetrahedron":
+        if reference.name in ["interval","triangle","tetrahedron","pyramid"]:
             poly += polynomial_set_1d(reference.tdim, order)
-        elif reference.name == "quadrilateral" or reference.name == "hexahedron":
+            if reference.name == "pyramid":
+                pol=pyramid_polynomial_set_1d(3, order)
+                for ii in range(order-1):
+                    poly.append(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)])
+                poly.append(pol[2*order+1])
+                if order>1:
+                    for ii in range(order-2):
+                        poly.append(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)])
+                        for jj in range(ii+1):
+                            poly.append(pol[3*order+1+ii*order+jj])
+                    poly.append(pol[order*(order+1)+1])
+        elif reference.name in ["quadrilateral","hexahedron"]:
             poly += quolynomial_set_1d(reference.tdim, order - 1)
             if reference.tdim == 2:
                 for i in range(2):
@@ -104,18 +114,6 @@ class TNT(CiarletElement):
                 poly.append(x[0]**i*x[1]**(order-i))
                 if order>1:
                     poly.append(x[0]**i*x[1]**(order-i)*x[2])
-        elif reference.name == "pyramid":
-            poly+=polynomial_set_1d(3,order)
-            pol=pyramid_polynomial_set_1d(3, order)
-            for ii in range(order-1):
-                poly.append(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)])
-            poly.append(pol[2*order+1])
-            if order>1:
-                for ii in range(order-2):
-                    poly.append(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)])
-                    for jj in range(ii+1):
-                        poly.append(pol[3*order+1+ii*order+jj])
-                poly.append(pol[order*(order+1)+1])
 
         dofs: ListOfFunctionals = []
         for i, v in enumerate(reference.vertices):
@@ -125,13 +123,13 @@ class TNT(CiarletElement):
         for edge_n,ii in product(range(reference.sub_entity_count(1)),range(1,order)): # skip 0th order as it falls in the kernel of the gradient
                 dofs.append(IntegralAgainst(reference, pol[ii].grad(1)[0], entity=(1, edge_n), mapping="identity")) 
 
-        if reference.name == "triangle" or reference.name == "tetrahedron":
+        if reference.name in ["triangle","tetrahedron"]:
             pol=polynomial_set_1d(2, order-3)
             for face_n,ii in product(range(reference.sub_entity_count(2)),range(len(pol))):
                 dofs.append(
                     IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity")
                 )
-        elif reference.name == "quadrilateral" or reference.name =="hexahedron":
+        elif reference.name in ["quadrilateral","hexahedron"]:
             pol=quolynomial_set_1d(2, order-3)
             for face_n,ii in product(range(reference.sub_entity_count(2)),range(len(pol))):
                 dofs.append(
@@ -198,7 +196,7 @@ class TNT(CiarletElement):
 
     @property
     def lagrange_subdegree(self) -> int:
-        if reference.name == "interval" or reference.name == "triangle" or reference.name == "tetrahedron":
+        if reference.name in ["interval","triangle","tetrahedron"]:
             return self.order
         else:
             return self.order - 1
@@ -213,7 +211,7 @@ class TNT(CiarletElement):
 
     @property
     def polynomial_superdegree(self) -> int | None:
-        if reference.name == "interval" or reference.name == "triangle" or reference.name == "tetrahedron":
+        if reference.name in ["interval","triangle","tetrahedron"]:
             return self.order
         else:
             return max((self.order - 1) * self.reference.tdim, (self.order - 1) + self.reference.tdim)
@@ -241,49 +239,56 @@ class TNTcurl(CiarletElement):
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        poly += quolynomial_set_vector(reference.tdim, reference.tdim, order)
-        if reference.tdim == 2:
-            for ii in product([0, 1], repeat=2):
-                if sum(ii) != 0:
-                    poly.append(
-                        tuple(
-                            sympy.S(j).expand()
-                            for j in [
-                                p(order, ii[0] * x[0]) * b(order + 1, ii[1] * x[1]),
-                                -b(order + 1, ii[0] * x[0]) * p(order, ii[1] * x[1]),
-                            ]
+        if reference.name in ["interval","triangle","tetrahedron"]:
+            poly += polynomial_set_vector(reference.tdim, reference.tdim, order)
+        elif reference.name in ["quadrilateral","hexahedron"]:
+            poly += quolynomial_set_vector(reference.tdim, reference.tdim, order)
+            if reference.tdim == 2:
+                for ii in product([0, 1], repeat=2):
+                    if sum(ii) != 0:
+                        poly.append(
+                            tuple(
+                                sympy.S(j).expand()
+                                for j in [
+                                    p(order, ii[0] * x[0]) * b(order + 1, ii[1] * x[1]),
+                                    -b(order + 1, ii[0] * x[0]) * p(order, ii[1] * x[1]),
+                                ]
+                            )
                         )
-                    )
-        else:
-            face_poly = []
-            for ii in product([0, 1], repeat=2):
-                if sum(ii) != 0:
-                    face_poly.append(
-                        tuple(
-                            sympy.S(j).expand()
-                            for j in [
-                                b(order + 1, ii[0] * t[0]) * p(order, ii[1] * t[1]),
-                                p(order, ii[0] * t[0]) * b(order + 1, ii[1] * t[1]),
-                            ]
+            else:
+                face_poly = []
+                for ii in product([0, 1], repeat=2):
+                    if sum(ii) != 0:
+                        face_poly.append(
+                            tuple(
+                                sympy.S(j).expand()
+                                for j in [
+                                    b(order + 1, ii[0] * t[0]) * p(order, ii[1] * t[1]),
+                                    p(order, ii[0] * t[0]) * b(order + 1, ii[1] * t[1]),
+                                ]
+                            )
                         )
-                    )
-            for lamb_n in [
-                (x[0], 0, 0),
-                (1 - x[0], 0, 0),
-                (0, x[1], 0),
-                (0, 1 - x[1], 0),
-                (0, 0, x[2]),
-                (0, 0, 1 - x[2]),
-            ]:
-                variables = tuple(i for i, j in enumerate(lamb_n) if j == 0)
-                for pf in face_poly:
-                    psub = VectorFunction(pf).subs(t[:2], [x[j] for j in variables])
-                    pc = VectorFunction(lamb_n).cross(
-                        VectorFunction(
-                            [psub[variables.index(i)] if i in variables else 0 for i in range(3)]
+                for lamb_n in [
+                    (x[0], 0, 0),
+                    (1 - x[0], 0, 0),
+                    (0, x[1], 0),
+                    (0, 1 - x[1], 0),
+                    (0, 0, x[2]),
+                    (0, 0, 1 - x[2]),
+                ]:
+                    variables = tuple(i for i, j in enumerate(lamb_n) if j == 0)
+                    for pf in face_poly:
+                        psub = VectorFunction(pf).subs(t[:2], [x[j] for j in variables])
+                        pc = VectorFunction(lamb_n).cross(
+                            VectorFunction(
+                                [psub[variables.index(i)] if i in variables else 0 for i in range(3)]
+                            )
                         )
-                    )
-                    poly.append(pc)
+                        poly.append(pc)
+        elif reference.name == "prism":
+            None
+        elif reference.name == "pyramid":
+            None
 
         dofs: ListOfFunctionals = []
         dofs += make_integral_moment_dofs(

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -196,7 +196,7 @@ class TNT(CiarletElement):
 
     @property
     def lagrange_subdegree(self) -> int:
-        if reference.name in ["interval","triangle","tetrahedron"]:
+        if self.reference.name in ["interval","triangle","tetrahedron"]:
             return self.order
         else:
             return self.order - 1
@@ -211,7 +211,7 @@ class TNT(CiarletElement):
 
     @property
     def polynomial_superdegree(self) -> int | None:
-        if reference.name in ["interval","triangle","tetrahedron"]:
+        if self.reference.name in ["interval","triangle","tetrahedron"]:
             return self.order
         else:
             return max((self.order - 1) * self.reference.tdim, (self.order - 1) + self.reference.tdim)

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -128,52 +128,52 @@ class TNT(CiarletElement):
         if reference.name in ["triangle", "tetrahedron"]:
             for face_n,pl in product(range(reference.sub_entity_count(2)),polynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity")
+                    IntegralAgainst(reference, ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2).div(), entity=(2, face_n), mapping="identity")
                 )
         elif reference.name in ["quadrilateral", "hexahedron"]:
             for face_n,pl in product(range(reference.sub_entity_count(2)),quolynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity")
+                    IntegralAgainst(reference, ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2).div(), entity=(2, face_n), mapping="identity")
                 ) 
         elif reference.name == "prism":
             for face_n,pl in product([0,4],polynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
+                    IntegralAgainst(reference, ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2).div(), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
                 )
             for face_n,pl in product(range(1,4),quolynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity")
+                    IntegralAgainst(reference, ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2).div(), entity=(2, face_n), mapping="identity")
                 ) 
         elif reference.name == "pyramid":
             for pl in quolynomial_set_1d(2, order-3):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2)), entity=(2, 0), mapping="identity")
+                    IntegralAgainst(reference, ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2).div(), entity=(2, 0), mapping="identity")
                 ) 
             for face_n,pl in product(range(1,5),polynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
+                    IntegralAgainst(reference, ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2).div(), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
                 )
                     
         if reference.name == "tetrahedron":
-            for ii in polynomial_set_1d(3, order-4):
+            for pl in polynomial_set_1d(3, order-4):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[1]-x[2])*pl).grad(3)),entity=(3, 0), mapping="identity")
+                    IntegralAgainst(reference, ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[1]-x[2])*pl).grad(3).div(),entity=(3, 0), mapping="identity")
                 )
         elif reference.name == "hexahedron":
             for pl in quolynomial_set_1d(3, order-3):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*pl).grad(3)),entity=(3, 0), mapping="identity")
+                    IntegralAgainst(reference, ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*pl).grad(3).div(),entity=(3, 0), mapping="identity")
                 )
         elif reference.name == "prism":
             pol=prism_polynomial_set_1d(3, order-3)
             for i,j in product(range((order - 2) * (order - 3)// 2),range(order - 2)): # no upper xy power
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*pol[i+j*(order-1)*(order-2)//2]).grad(3)),entity=(3, 0), mapping="identity")
+                    IntegralAgainst(reference, ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*pol[i+j*(order-1)*(order-2)//2]).grad(3).div(),entity=(3, 0), mapping="identity")
                 )
         elif reference.name == "pyramid":
             for pl in polynomial_set_1d(3, order-5):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3)),entity=(3, 0), mapping="identity")
+                    IntegralAgainst(reference, ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3).div(),entity=(3, 0), mapping="identity")
                 )
 
         super().__init__(reference, order, poly, dofs, reference.tdim, 1)
@@ -311,12 +311,18 @@ class TNTcurl(CiarletElement):
                     poly.pop(4)
         elif reference.name == "prism":
             poly += prism_polynomial_set_vector(reference.tdim, reference.tdim, order-1)
-            for i in range(order):
-                poly.append(VectorFunction([x[1],-x[0],0])*x[0]**i*x[1]**(order-i-1))
-                poly.append(VectorFunction([x[1],-x[0],0])*x[0]**i*x[1]**(order-i-1)*x[2])
-            for i in range(order+1):  
-                poly.append(VectorFunction([0,0,x[0]**i*x[1]**(order-i)]).curl().cross(VectorFunction([x[0],x[1],x[2]]))*x[2]**(order-1))  # modified from Cockburn & Fu
-                poly.append(ScalarFunction(x[0]**i*x[1]**(order-i)*x[2]).grad(3)) # P~_order(x[0],x[1])*x[2]
+            for pl in polynomial_set_1d(2,order-1)[-order:]:
+                poly.append(VectorFunction([x[1],-x[0],0])*pl)
+                poly.append(VectorFunction([x[1],-x[0],0])*pl*x[2])
+#            for i in range(order):
+#                poly.append(VectorFunction([x[1],-x[0],0])*x[0]**i*x[1]**(order-i-1))
+#                poly.append(VectorFunction([x[1],-x[0],0])*x[0]**i*x[1]**(order-i-1)*x[2])
+            for pl in polynomial_set_1d(2,order)[-order-1:]:
+                poly.append(VectorFunction([0,0,pl]).curl().cross(VectorFunction([x[0],x[1],x[2]]))*x[2]**(order-1))  # modified from Cockburn & Fu
+                poly.append(ScalarFunction(x[2]*pl).grad(3)) # P~_order(x[0],x[1])*x[2]
+#            for i in range(order+1):
+#                poly.append(VectorFunction([0,0,x[0]**i*x[1]**(order-i)]).curl().cross(VectorFunction([x[0],x[1],x[2]]))*x[2]**(order-1))  # modified from Cockburn & Fu
+#                poly.append(ScalarFunction(x[0]**i*x[1]**(order-i)*x[2]).grad(3)) # P~_order(x[0],x[1])*x[2]
             if order > 1:
                 for pl in polynomial_set_1d(2, 1)[1:]:  
                     poly.append(ScalarFunction(x[2]**order*pl).grad(3))  # P_1(x[0],x[1])*x[2]**order
@@ -380,15 +386,15 @@ class TNTcurl(CiarletElement):
             pol=quolynomial_set_1d(3, order - 3)
             for pl in pol:
                 dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))                
-                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
-                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))                
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
             for i in range(order-2):
                 for j in range(order-2):
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*pol[i * (order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1]*(1-x[1])* x[2]*(1-x[2]),0])*pol[i * (order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pol[i*(order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))             
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pol[i*(order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))                
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*pol[i * (order-2)*(order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))
                     dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* (1-x[1])*x[2]*(1-x[2]),0])*pol[i * (order-2)*(order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*pol[i * (order-2)*(order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*pol[i * (order-2)*(order-2)+j*(order-2)]).curl().curl(),entity=(3,0),mapping="covariant"))
                     dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])])*pol[i * (order-2)*(order-2)+j*(order-2)+order-3]).curl().curl(),entity=(3,0),mapping="covariant"))
         elif reference.name == "prism":
             pol=prism_polynomial_set_1d(3, order - 3)
@@ -407,15 +413,16 @@ class TNTcurl(CiarletElement):
             symmetricpyramid=0 # 0 or 1
             pol=polynomial_set_1d(3, order - 4)
             for pl in pol:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetericpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
             for pl in pol[-(order-3)*(order-2)//2:]:           
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetericpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),x[0]*x[1]*x[2]*(1-x[1]-x[2]),0])*pl).curl().curl,entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
             pol=polynomial_set_1d(3, order - 5)
             for pl in pol:
-               dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
+               dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))
         order-=1
+#        print("tntcurl",reference.name,order)
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
 
@@ -545,11 +552,11 @@ class TNTdiv(CiarletElement):
                 pol=polynomial_set_1d(3, order - 4)
                 symmetricpyramid=0 # 0 or 1
                 for pl in pol:
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetericpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
                 for pl in pol[-(order-3)*(order-2)//2:]:           
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetericpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),x[0]*x[1]*x[2]*(1-x[1]-x[2]),0])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0])*pl).curl(),entity=(3,0),mapping="contravariant"))
         elif reference.name in ["quadrilateral", "hexahedron"]:
             for pl in quolynomial_set_1d(reference.tdim, order - 1)[1:]:
                 dofs.append(IntegralAgainst(reference, pl.grad(reference.tdim), entity=(reference.tdim, 0), mapping="contravariant"))
@@ -558,16 +565,16 @@ class TNTdiv(CiarletElement):
                     dofs.append(IntegralAgainst(reference, ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).curl(), entity=(2,0), mapping="contravariant"))  # modified from Cockburn & Qiu : grad -> curl to avoid singular Vandermonde matrix 
             elif reference.name == "hexahedron":
                 pol=quolynomial_set_1d(3, order - 3)
-                for pl in pol:
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))             
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))                
+                for pl in pol:              
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2]),0])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))
                 for i in range(order-2):
                     for j in range(order-2):
-                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*pol[i * (order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))
-                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1]*(1-x[1])* x[2]*(1-x[2]),0])*pol[i * (order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))
+                        dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pol[i*(order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))             
+                        dofs.append(IntegralAgainst(reference,(VectorFunction([(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pol[i*(order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))                
+                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*pol[i * (order-2)*(order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))
                         dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* (1-x[1])*x[2]*(1-x[2]),0])*pol[i * (order-2)*(order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))
-                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*pol[i * (order-2)*(order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))
+                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*pol[i * (order-2)*(order-2)+j*(order-2)]).curl(),entity=(3,0),mapping="contravariant"))
                         dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])])*pol[i * (order-2)*(order-2)+j*(order-2)+order-3]).curl(),entity=(3,0),mapping="contravariant"))
         elif reference.name == "prism":
             pol=prism_polynomial_set_1d(3, order - 3)

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -543,43 +543,7 @@ class TNTdiv(CiarletElement):
                             x[2] ** k
                             * x[1] ** (j - 1)
                             * (1 - x[1])
-                            * x[0] ** (i - 2)"""TiNiest Tensor product (TNT) elements.
-
-These elements' definitions appear in https://doi.org/10.1090/S0025-5718-2013-02729-9
-(Cockburn, Qiu, 2013)
-"""
-
-import typing
-from itertools import product
-
-import sympy
-
-from symfem.elements.q import Q
-from symfem.finite_element import CiarletElement
-from symfem.functionals import (
-    IntegralAgainst,
-    ListOfFunctionals,
-    NormalIntegralMoment,
-    PointEvaluation,
-    TangentIntegralMoment,
-)
-from symfem.functions import FunctionInput, ScalarFunction, VectorFunction
-from symfem.moments import make_integral_moment_dofs
-from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector, polynomial_set_1d, polynomial_set_vector, prism_polynomial_set_1d, pyramid_polynomial_set_1d
-from symfem.references import NonDefaultReferenceError, Reference
-from symfem.symbols import t, x
-
-__all__ = ["p", "b", "TNT", "TNTcurl", "TNTdiv"]
-
-
-def p(k: int, v: sympy.core.symbol.Symbol) -> ScalarFunction:
-    """Return the kth Legendre polynomial.
-
-    Args:
-        k: k
-        v: The variable to use
-
-
+                            * x[0] ** (i - 2)
                             * (i * x[0] - i + 1),
                             0,
                         )

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -228,7 +228,7 @@ class TNTcurl(CiarletElement):
             order: The polynomial order
             variant: The variant of the element
         """
-#        order+=1
+        order+=1
         if reference.vertices != reference.reference_vertices:
             raise NonDefaultReferenceError()
 
@@ -259,7 +259,7 @@ class TNTcurl(CiarletElement):
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
                 for ii in product([0, 1], repeat=2):
-                    if sum(ii) != 0 and (order!=1 or sum(ii)!=2):
+                    if sum(ii) > 0 and (order > 1 or sum(ii) < 2):
                         poly.append(
                             tuple(
                                 sympy.S(j).expand()
@@ -272,7 +272,7 @@ class TNTcurl(CiarletElement):
             else:
                 face_poly = []
                 for ii in product([0, 1], repeat=2):
-                    if sum(ii) != 0:
+                    if sum(ii) > 0:
                         face_poly.append(
                             tuple(
                                 sympy.S(j).expand()
@@ -299,6 +299,16 @@ class TNTcurl(CiarletElement):
                             )
                         )
                         poly.append(pc)
+                if order==1: # sniff out dependents
+                    poly.pop(20)
+                    poly.pop(19)
+                    poly.pop(17)
+                    poly.pop(13)
+                    poly.pop(12)
+                    poly.pop(11)
+                    poly.pop(8)
+                    poly.pop(7)
+                    poly.pop(4)
         elif reference.name == "prism":
             poly += prism_polynomial_set_vector(reference.tdim, reference.tdim, order-1)
             for i in range(order):
@@ -405,9 +415,7 @@ class TNTcurl(CiarletElement):
             pol=polynomial_set_1d(3, order - 5)
             for pl in pol:
                dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
-
-        print(reference.name, order, order-1, poly)
-#        order-=1
+        order-=1
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
 
@@ -454,7 +462,7 @@ class TNTdiv(CiarletElement):
             order: The polynomial order
             variant: The variant of the element
         """
-#        order+=1
+        order+=1
         if reference.vertices != reference.reference_vertices:
             raise NonDefaultReferenceError()
 
@@ -476,7 +484,7 @@ class TNTdiv(CiarletElement):
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
                 for ii in product([0, 1], repeat=2):
-                    if sum(ii) != 0:
+                    if sum(ii) > 0 and (order > 1 or sum(ii) < 2):
                         poly.append(
                             tuple(
                                 sympy.S(j).expand()
@@ -488,20 +496,14 @@ class TNTdiv(CiarletElement):
                         )
             else:
                 for ii in product([0, 1], repeat=3):
-                    if sum(ii) != 0:
+                    if sum(ii) > 0  and (order > 1 or sum(ii) < 2):
                         poly.append(
                             (
-                                b(order, ii[0] * x[0])
-                                * p(order - 1, ii[1] * x[1])
-                                * p(order - 1, ii[2] * x[2]),
-                                p(order - 1, ii[0] * x[0])
-                                * b(order, ii[1] * x[1])
-                                * p(order - 1, ii[2] * x[2]),
-                                p(order - 1, ii[0] * x[0])
-                                * p(order - 1, ii[1] * x[1])
-                                * b(order, ii[2] * x[2]),
+                                b(order, ii[0] * x[0]) * p(order - 1, ii[1] * x[1]) * p(order - 1, ii[2] * x[2]),
+                                p(order - 1, ii[0] * x[0])  * b(order, ii[1] * x[1])  * p(order - 1, ii[2] * x[2]),
+                                p(order - 1, ii[0] * x[0]) * p(order - 1, ii[1] * x[1]) * b(order, ii[2] * x[2]),
                             )
-                        )
+                        )              
         elif reference.name == "prism":
             poly += prism_polynomial_set_vector(reference.tdim, reference.tdim, order-1)
             for i in range(order):
@@ -580,8 +582,7 @@ class TNTdiv(CiarletElement):
                 dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*(1-x[2])])*pol[i*(order  - 2)]).curl(),entity=(3,0),mapping="contravariant"))
             for pl in prism_polynomial_set_1d(3, order - 1)[1:]:
                 dofs.append(IntegralAgainst(reference,pl.grad(3),entity=(3,0),mapping="contravariant"))                           
-#        print(reference.name, order, poly)
-#        order-=1
+        order-=1
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
 

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -1,7 +1,7 @@
 """TiNiest Tensor product (TNT) elements.
 
 These elements' definitions appear in https://doi.org/10.1090/S0025-5718-2013-02729-9
-(Cockburn, Qiu, 2013) and https://doi.org/10.1137/16M1073352 (Cockburn, Fu, 2017)
+(Cockburn, Qiu, 2013)
 """
 
 import typing
@@ -64,7 +64,6 @@ class TNT(CiarletElement):
 
     def __init__(self, reference: Reference, order: int, variant: str = "equispaced"):
         """Create the element.
-                f = sympy.Integer(1)
 
         Args:
             reference: The reference element
@@ -562,43 +561,7 @@ class TNTdiv(CiarletElement):
         return self.order + 1
 
     @property
-    def polynomial_subdegree(self) -> int:"""TiNiest Tensor product (TNT) elements.
-
-These elements' definitions appear in https://doi.org/10.1090/S0025-5718-2013-02729-9
-(Cockburn, Qiu, 2013)
-"""
-
-import typing
-from itertools import product
-
-import sympy
-
-from symfem.elements.q import Q
-from symfem.finite_element import CiarletElement
-from symfem.functionals import (
-    DerivativeIntegralMoment,
-    IntegralAgainst,
-    ListOfFunctionals,
-    NormalIntegralMoment,
-    PointEvaluation,
-    TangentIntegralMoment,
-)
-from symfem.functions import FunctionInput, ScalarFunction, VectorFunction
-from symfem.moments import make_integral_moment_dofs
-from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector
-from symfem.references import NonDefaultReferenceError, Reference
-from symfem.symbols import t, x
-
-__all__ = ["p", "b", "TNT", "TNTcurl", "TNTdiv"]
-
-
-def p(k: int, v: sympy.core.symbol.Symbol) -> ScalarFunction:
-    """Return the kth Legendre polynomial.
-
-    Args:
-        k: k
-        v: The variable to use
-
+    def polynomial_subdegree(self) -> int:
         return self.order
 
     @property

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -356,26 +356,26 @@ class TNTcurl(CiarletElement):
         # Interior Moments
         if reference.name == "tetrahedron":
             pol=polynomial_set_1d(3, order - 3)
-            for f in pol:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*x[2]*(1-x[0]-x[1]-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1]-x[2])])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-            for f in pol[-(order-2)*(order-1)//2:]:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[1]-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+            for pl in pol:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*x[2]*(1-x[0]-x[1]-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+            for pl in pol[-(order-2)*(order-1)//2:]:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[1]-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
             pol=polynomial_set_1d(3, order - 4)
-            for f in pol:
-                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[1]-x[2])*f).grad(3),entity=(3,0),mapping="covariant"))
+            for pl in pol:
+                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))
         elif reference.name == "hexahedron":
             pol=quolynomial_set_1d(3, order - 3)
-            for f in pol:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))             
-                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))                
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1]*(1-x[1])* x[2]*(1-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* (1-x[1])*x[2]*(1-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*f).grad(3),entity=(3,0),mapping="covariant"))                
+            for pl in pol:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))                
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1]*(1-x[1])* x[2]*(1-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* (1-x[1])*x[2]*(1-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))                
         elif reference.name == "hexahedronn":
             for i in range(1, order - 1):
                 for j in range(1, order - 1):
@@ -423,13 +423,25 @@ class TNTcurl(CiarletElement):
                         )
         elif reference.name == "prism":
             pol=prism_polynomial_set_1d(3, order - 3)
-            for f in pol:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*(1-x[0]-x[1])*x[2]*(1-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))             
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0]-x[1])*x[2]*(1-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))             
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])])*f).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*(1-x[2])])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+            for pl in pol:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*(1-x[0]-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0]-x[1])*x[2]*(1-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*(1-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
 #                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*f).grad(3),entity=(3,0),mapping="covariant"))   
+
+        elif reference.name == "pyramid":
+            pol=prism_polynomial_set_1d(3, order - 4)
+            for pl in pol:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*x[1]*x[2]*(1-x[1]-x[2]),x[0]*x[1]*x[2]*(1-x[1]-x[2]),0]).pl).curl().curl(),entity=(3,0),mapping="covariant"))
+            pol=prism_polynomial_set_1d(3, order - 5)
+            for pl in pol:
+               dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
+
 
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -13,6 +13,7 @@ from itertools import product
 import sympy
 
 from symfem.elements.q import Q
+from symfem.elements.lagrange import Lagrange
 from symfem.finite_element import CiarletElement
 from symfem.functionals import (
     IntegralAgainst,
@@ -20,10 +21,11 @@ from symfem.functionals import (
     NormalIntegralMoment,
     PointEvaluation,
     TangentIntegralMoment,
+    IntegralMoment
 )
 from symfem.functions import FunctionInput, ScalarFunction, VectorFunction
 from symfem.moments import make_integral_moment_dofs
-from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector, polynomial_set_1d, polynomial_set_vector, prism_polynomial_set_1d, prism_polynomial_set_vector, pyramid_polynomial_set_1d, Hcurl_polynomials
+from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector, polynomial_set_1d, polynomial_set_vector, prism_polynomial_set_1d, prism_polynomial_set_vector, pyramid_polynomial_set_1d, Hcurl_polynomials, Hdiv_polynomials
 from symfem.references import NonDefaultReferenceError, Reference
 from symfem.symbols import t, x
 
@@ -81,11 +83,11 @@ class TNT(CiarletElement):
             if reference.name == "pyramid":
                 pol=pyramid_polynomial_set_1d(3, order)
                 for ii in range(order-1):
-                    poly.append(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)])
+                    poly.append(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]) # x y/(1-w) P~_order-2(x,z) modified from Cockburn & Fu
                 poly.append(pol[2*order+1])
                 if order>1:
                     for ii in range(order-2):
-                        poly.append(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)])
+                        poly.append(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]) # x y z/(1-w) P~_order-3(y,z) modified from Cockburn & Fu
                         for jj in range(ii+1):
                             poly.append(pol[3*order+1+ii*order+jj])
                     poly.append(pol[order*(order+1)+1])
@@ -226,6 +228,7 @@ class TNTcurl(CiarletElement):
             order: The polynomial order
             variant: The variant of the element
         """
+        order+=1
         if reference.vertices != reference.reference_vertices:
             raise NonDefaultReferenceError()
 
@@ -235,23 +238,34 @@ class TNTcurl(CiarletElement):
             poly += Hcurl_polynomials(reference.tdim,reference.tdim,order)
             if reference.name == "pyramid":
                 pol=pyramid_polynomial_set_1d(3, order)
-                print(pol)
-                for ii in range(order-1):
-                    poly.append(ScalarFunction(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]).grad(3))
+#                print("NN",2*order+1,pol[2*order+1],ScalarFunction(pol[2*order+1]).grad(3))        
                 poly.append(ScalarFunction(pol[2*order+1]).grad(3))
                 if order>1:
-                    for ii in range(order-2):
-                        poly.append(ScalarFunction(pol[(order+1)*(order+2)*(2*order+3)//6-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]).grad(3))
-                        for jj in range(ii+1):
-                            poly.append(ScalarFunction(pol[3*order+1+ii*order+jj]).grad(3))
+#                    print("OO",order*(order+1)+1,pol[order*(order+1)+1],ScalarFunction(pol[order*(order+1)+1]).grad(3))        
                     poly.append(ScalarFunction(pol[order*(order+1)+1]).grad(3))
+                    for ii in range(order-1):
+#                        print("AA",ii,-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii),pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)],ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]).grad(3))
+                        poly.append(ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]).grad(3))
+                    for ii in range(order-2):
+#                        print("BB",ii,-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii),pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)],ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]).grad(3))                   
+                        poly.append(ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]).grad(3))
+                        for jj in range(ii+1):
+#                            print("CC",ii,jj,3*order+1+ii*order+jj,pol[3*order+1+ii*order+jj],ScalarFunction(pol[3*order+1+ii*order+jj]).grad(3))                   
+                            poly.append(ScalarFunction(pol[3*order+1+ii*order+jj]).grad(3))
+                    for ii in range(order-1):
+                        for jj in range(ii+1):
+#                            print("DD",ii,jj,pol[order-1-ii+jj+(1+ii)*(order+1)],"AAA",VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)])                   
+                            poly.append(VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)]) 
                 pol=polynomial_set_vector(3,3,0)
-                for pl in pol[max(4-2*order,0):]:
-                    poly.append(x[0]*x[1]/(1-x[2])*pl) # modified from Cockburn & Fu
-                pol=pyramid_polynomial_set_1d(3,order-1)
-                for ii in range(order-1):
-                    for jj in range(ii+1):
-                        poly.append(VectorFunction([x[1],-x[0],0])*pol[ii+1+(jj+1)*(order+1)]) 
+                if order>1:
+                    poly.append(pol[0]*x[0]**(order-1)*x[1]/(1-x[2]))  # modified from Cockburn & Fu
+                    poly.append(pol[1]*x[0]*x[1]**(order-1)/(1-x[2]))  # modified from Cockburn & Fu
+                poly.append(pol[2]*x[0]*x[1]/(1-x[2]))       # modified from Cockburn & Fu
+#                poly.append(pol[2]*x[0]*x[1]**order/(1-x[2]))
+#                poly.append(pol[2]*x[0]**order*x[1]/(1-x[2]))
+#                for pl in pol[max(4-2*order,0):]:
+#                    print("EE",(x[0]*x[1]**order/(1-x[2])*pl/100))
+#                    poly.append(x[0]*x[1]**order/(1-x[2])*pl/100) 
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
@@ -308,7 +322,6 @@ class TNTcurl(CiarletElement):
                 for pl in polynomial_set_1d(2, 1)[1:]:  
                     poly.append(ScalarFunction(x[2]**order*pl).grad(3))  # P_1(x[0],x[1])*x[2]**order
                 poly.append(VectorFunction([x[1],-x[0],0])*x[2]**order)
-            print(reference.name,order,poly)
                     
         dofs: ListOfFunctionals = []
         dofs += make_integral_moment_dofs(reference, edges=(TangentIntegralMoment, Q, order - 1, {"variant": variant}))
@@ -321,7 +334,7 @@ class TNTcurl(CiarletElement):
                 face_moments_s.append(pl.curl())
             pol=polynomial_set_1d(2, order - 3)
             for pl in pol:
-                face_moments_s.append(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2))
+                face_moments_s.append(ScalarFunction(-x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2))
         if reference.name in ["quadrilateral", "hexahedron", "prism", "pyramid"]:
             face_moments_q = []
             pol=quolynomial_set_1d(2, order - 1)
@@ -349,7 +362,7 @@ class TNTcurl(CiarletElement):
                 dofs.append(IntegralAgainst(reference, f[0], entity=(2, f[1]), mapping="covariant"))
         elif reference.name == "pyramid":
             for f in face_moments_q:
-                dofs.append(IntegralAgainst(reference, f[0], entity=(2, 0), mapping="covariant"))
+                dofs.append(IntegralAgainst(reference, f, entity=(2, 0), mapping="covariant"))
             for f in product(face_moments_s, range(1,5)):
                 dofs.append(IntegralAgainst(reference, f[0], entity=(2, f[1]), mapping="covariant"))
             
@@ -425,23 +438,36 @@ class TNTcurl(CiarletElement):
             pol=prism_polynomial_set_1d(3, order - 3)
             for pl in pol:
                 dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*(1-x[0]-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0]-x[1])*x[2]*(1-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
                 dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*(1-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-#                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*f).grad(3),entity=(3,0),mapping="covariant"))   
-
+            for y in range(order-2):
+                for z in range(order-2):
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0]-x[1])*x[2]*(1-x[2]),0])*pol[y*(y+1)//2*(order-2)+z]).curl().curl(),entity=(3,0),mapping="covariant"))
+            for i in range((order-1) * (order-2)//2):
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]])*pol[i*(order  - 2)]).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*(1-x[2])])*pol[i*(order  - 2)]).curl().curl(),entity=(3,0),mapping="covariant"))
+            for pl in pol[:-(order-2)*(order-2)]:
+                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
         elif reference.name == "pyramid":
-            pol=prism_polynomial_set_1d(3, order - 4)
+            symmetricpyramid=0 # 0 or 1
+            pol=polynomial_set_1d(3, order - 4)
+                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetericpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+            for pl in pol[-(order-3)*(order-2)//2:]:           
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetericpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),x[0]*x[1]*x[2]*(1-x[1]-x[2]),0])*pl).curl().curl,entity=(3,0),mapping="covariant"))
+            pol=polynomial_set_1d(3, order - 5)
             for pl in pol:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*x[1]*x[2]*(1-x[1]-x[2]),x[0]*x[1]*x[2]*(1-x[1]-x[2]),0]).pl).curl().curl(),entity=(3,0),mapping="covariant"))
-            pol=prism_polynomial_set_1d(3, order - 5)
-            for pl in pol:
-               dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
+               dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
 
+#            for pl in pol:
+#                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
+#                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+#            for pl in pol[-(order-3)*(order-2)//2:]:           
+#                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[1]*x[0]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+#                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*x[1]*x[2]*(1-x[1]-x[2]),x[0]*x[1]*x[2]*(1-x[1]-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+#            pol=polynomial_set_1d(3, order - 5)
+#            for pl in pol:
+#               dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
 
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
@@ -456,26 +482,26 @@ class TNTcurl(CiarletElement):
 
     @property
     def lagrange_subdegree(self) -> int:
-        return self.order - 1
+        return self.order - 1  # this needs fixing
 
     @property
     def lagrange_superdegree(self) -> int | None:
-        return self.order
+        return self.order  # this needs fixing
 
     @property
     def polynomial_subdegree(self) -> int:
-        return self.order - 1
+        return self.order - 1  # this needs fixing
 
     @property
     def polynomial_superdegree(self) -> int | None:
-        return (self.order - 1) * self.reference.tdim + 1
+        return (self.order - 1) * self.reference.tdim + 1  # this needs fixing
 
     names = ["tiniest tensor Hcurl", "TNTcurl"]
     references = ["interval", "triangle", "quadrilateral", "tetrahedron", "hexahedron", "prism", "pyramid"]
-    min_order = 1
+    min_order = 0
     continuity = "H(curl)"
     value_type = "vector"
-    last_updated = "2025.10"
+    last_updated = "2026.1"
 
 
 class TNTdiv(CiarletElement):
@@ -489,133 +515,213 @@ class TNTdiv(CiarletElement):
             order: The polynomial order
             variant: The variant of the element
         """
+        order+=1
         if reference.vertices != reference.reference_vertices:
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        poly += quolynomial_set_vector(reference.tdim, reference.tdim, order)
-        if reference.tdim == 2:
-            for ii in product([0, 1], repeat=2):
-                if sum(ii) != 0:
-                    poly.append(
-                        tuple(
-                            sympy.S(j).expand()
-                            for j in [
-                                b(order + 1, ii[0] * x[0]) * p(order, ii[1] * x[1]),
-                                p(order, ii[0] * x[0]) * b(order + 1, ii[1] * x[1]),
-                            ]
+        if reference.name in ["interval", "triangle", "tetrahedron", "pyramid"]:
+            poly += polynomial_set_vector(reference.tdim, reference.tdim, order-1)
+            poly += Hdiv_polynomials(reference.tdim,reference.tdim,order)
+            if reference.name == "pyramid":
+                pol=pyramid_polynomial_set_1d(3, order)
+                if order>1:
+                    for ii in range(order-1):
+                        for jj in range(ii+1):
+                            poly.append((VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)]).curl()) 
+                pol=polynomial_set_vector(3,3,0)
+                if order>1:
+                    poly.append((pol[0]*x[0]**(order-1)*x[1]/(1-x[2])).curl())  # modified from Cockburn & Fu
+                    poly.append((pol[1]*x[1]**(order-1)*x[0]/(1-x[2])).curl())  # modified from Cockburn & Fu
+                poly.append((pol[2]*x[0]*x[1]/(1-x[2])).curl())       # modified from Cockburn & Fu
+#                poly.append(pol[2]*x[0]*x[1]**order/(1-x[2]))
+#                poly.append(pol[2]*x[0]**order*x[1]/(1-x[2]))
+#                for pl in pol[max(4-2*order,0):]:
+#                    print("EE",(x[0]*x[1]**order/(1-x[2])*pl/100))
+#                    poly.append(x[0]*x[1]**order/(1-x[2])*pl/100) 
+        elif reference.name in ["quadrilateral", "hexahedron"]:
+            poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
+            if reference.tdim == 2:
+                for ii in product([0, 1], repeat=2):
+                    if sum(ii) != 0:
+                        poly.append(
+                            tuple(
+                                sympy.S(j).expand()
+                                for j in [
+                                    b(order, ii[0] * x[0]) * p(order, ii[1] * x[1]),
+                                    p(order - 1, ii[0] * x[0]) * b(order + 1, ii[1] * x[1]),
+                                ]
+                            )
                         )
-                    )
-        else:
-            for ii in product([0, 1], repeat=3):
-                if sum(ii) != 0:
-                    poly.append(
-                        (
-                            b(order + 1, ii[0] * x[0])
-                            * p(order, ii[1] * x[1])
-                            * p(order, ii[2] * x[2]),
-                            p(order, ii[0] * x[0])
-                            * b(order + 1, ii[1] * x[1])
-                            * p(order, ii[2] * x[2]),
-                            p(order, ii[0] * x[0])
-                            * p(order, ii[1] * x[1])
-                            * b(order + 1, ii[2] * x[2]),
+            else:
+                for ii in product([0, 1], repeat=3):
+                    if sum(ii) != 0:
+                        poly.append(
+                            (
+                                b(order, ii[0] * x[0])
+                                * p(order - 1, ii[1] * x[1])
+                                * p(order - 1, ii[2] * x[2]),
+                                p(order - 1, ii[0] * x[0])
+                                * b(order, ii[1] * x[1])
+                                * p(order - 1, ii[2] * x[2]),
+                                p(order - 1, ii[0] * x[0])
+                                * p(order - 1, ii[1] * x[1])
+                                * b(order, ii[2] * x[2]),
+                            )
                         )
-                    )
-
+        elif reference.name == "prism":
+            poly += prism_polynomial_set_vector(reference.tdim, reference.tdim, order-1)
+            for i in range(order):
+                poly.append((VectorFunction([0,0,1])*x[0]**i*x[1]**(order-i-1)*x[2]**order))
+                poly.append((VectorFunction([x[1],-x[0],0])*x[0]**i*x[1]**(order-i-1)*x[2]).curl())
+            if order > 1:
+                poly.append((VectorFunction([x[1],-x[0],0])*x[2]**order).curl())
+ 
         dofs: ListOfFunctionals = []
-        dofs += make_integral_moment_dofs(
-            reference,
-            facets=(NormalIntegralMoment, Q, order, {"variant": variant}),
-        )
-
-        for ii in product(range(order + 1), repeat=reference.tdim):
-            if sum(ii) > 0:
-                if reference.tdim == 2:
-                    f = x[0] ** ii[0] * x[1] ** ii[1]
-                else:
-                    f = x[0] ** ii[0] * x[1] ** ii[1] * x[2] ** ii[2]
-                grad_f = ScalarFunction(f).grad(reference.tdim)
+        if reference.tdim == 3:
+            dofs += make_integral_moment_dofs(
+                reference,
+                faces={"triangle": (NormalIntegralMoment, Lagrange, order - 1, {"variant": variant}), "quadrilateral": (NormalIntegralMoment, Q, order - 1, {"variant": variant})}
+            )
+        elif reference.tdim == 2: # rotated 1-Form
+            dofs += make_integral_moment_dofs(
+                reference,
+                facets=(NormalIntegralMoment, Q, order - 1, {"variant": variant})
+            )
+        if reference.name in ["triangle"]: # rotated 1-Form
+            face_moments_s = []
+            pol=polynomial_set_1d(2, order - 1)
+            for pl in pol[1:]:
+                face_moments_s.append(pl.grad(2))
+            pol=polynomial_set_1d(2, order - 3)
+            for pl in pol:
+                face_moments_s.append(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).curl()) # modified from Cockburn & Qiu : grad -> curl to avoid singular Vandermonde matrix 
+            for f in face_moments_s:
+                dofs.append(IntegralAgainst(reference, f, entity=(2,0), mapping="contravariant"))                    
+        elif reference.name in ["tetrahedron", "pyramid"]:
+            for pl in polynomial_set_1d(reference.tdim,order-1)[1:]:
                 dofs.append(
                     IntegralAgainst(
-                        reference, grad_f, entity=(reference.tdim, 0), mapping="contravariant"
+                        reference, pl.grad(reference.tdim), entity=(reference.tdim, 0), mapping="contravariant"
                     )
                 )
-
-        if reference.tdim == 2:
-            for i in range(2, order + 1):
-                for j in range(2, order + 1):
-                    f = (
-                        x[0] ** (i - 1) * (1 - x[0]) * x[1] ** (j - 2) * (j - 1 - j * x[1]),
-                        x[1] ** (j - 1) * (1 - x[1]) * x[0] ** (i - 2) * (i * x[0] - i + 1),
-                    )
+            if reference.name == "tetrahedron":
+                pol=polynomial_set_1d(3, order - 3)
+                for pl in pol:
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*x[2]*(1-x[0]-x[1]-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                for pl in pol[-(order-2)*(order-1)//2:]:
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[1]-x[2]),0])*pl).curl(),entity=(3,0),mapping="contravariant"))
+            else:
+                pol=polynomial_set_1d(3, order - 4)
+                symmetricpyramid=0 # 0 or 1
+                for pl in pol:
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetericpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                for pl in pol[-(order-3)*(order-2)//2:]:           
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetericpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),x[0]*x[1]*x[2]*(1-x[1]-x[2]),0])*pl).curl(),entity=(3,0),mapping="contravariant"))
+        elif reference.name in ["quadrilateral", "hexahedron"]:
+            for ii in product(range(order), repeat=reference.tdim):
+                if sum(ii) > 0:
+                    if reference.tdim == 2:
+                        f = x[0] ** ii[0] * x[1] ** ii[1]
+                    else:
+                        f = x[0] ** ii[0] * x[1] ** ii[1] * x[2] ** ii[2]
+                    grad_f = ScalarFunction(f).grad(reference.tdim)
                     dofs.append(
                         IntegralAgainst(
-                            reference, f, entity=(reference.tdim, 0), mapping="contravariant"
+                            reference, grad_f, entity=(reference.tdim, 0), mapping="contravariant"
                         )
                     )
-        if reference.tdim == 3:
-            for i in range(2, order + 1):
-                for j in range(2, order + 1):
-                    for k in range(order + 1):
+            if reference.tdim == 2:  # rotated 1-Form
+                for i in range(2, order):
+                    for j in range(2, order):
                         f = (
-                            x[2] ** k
-                            * x[0] ** (i - 1)
-                            * (1 - x[0])
-                            * x[2] ** (j - 2)
-                            * (j - 1 - j * x[1]),
-                            x[2] ** k
-                            * x[1] ** (j - 1)
-                            * (1 - x[1])
-                            * x[0] ** (i - 2)
-                            * (i * x[0] - i + 1),
-                            0,
+                            x[0] ** (i - 1) * (1 - x[0]) * x[1] ** (j - 2) * (j - 1 - j * x[1]),
+                            x[1] ** (j - 1) * (1 - x[1]) * x[0] ** (i - 2) * (i * x[0] - i + 1),
                         )
                         dofs.append(
                             IntegralAgainst(
                                 reference, f, entity=(reference.tdim, 0), mapping="contravariant"
                             )
                         )
-                        f = (
-                            x[1] ** k
-                            * x[0] ** (i - 1)
-                            * (1 - x[0])
-                            * x[2] ** (j - 2)
-                            * (j - 1 - j * x[2]),
-                            0,
-                            x[1] ** k
-                            * x[2] ** (j - 1)
-                            * (1 - x[2])
-                            * x[0] ** (i - 2)
-                            * (i * x[0] - i + 1),
-                        )
-                        dofs.append(
-                            IntegralAgainst(
-                                reference, f, entity=(reference.tdim, 0), mapping="contravariant"
-                            )
-                        )
-                        if k in [0, 2]:
+            if reference.tdim == 3:
+                for i in range(2, order):
+                    for j in range(2, order):
+                        for k in range(order):
                             f = (
-                                0, x[0] ** k
-                                * x[1] ** (i - 1)
-                                * (1 - x[1])
+                                x[2] ** k
+                                * x[0] ** (i - 1)
+                                * (1 - x[0])
                                 * x[2] ** (j - 2)
-                                * (j - 1 - j * x[2]),
-                                x[0] ** k
-                                * x[2] ** (j - 1)
-                                * (1 - x[2])
-                                * x[1] ** (i - 2)
-                                * (i * x[1] - i + 1),
+                                * (j - 1 - j * x[1]),
+                                x[2] ** k
+                                * x[1] ** (j - 1)
+                                * (1 - x[1])
+                                * x[0] ** (i - 2)
+                                * (i * x[0] - i + 1),
+                                0,
                             )
                             dofs.append(
                                 IntegralAgainst(
-                                    reference,
-                                    f,
-                                    entity=(reference.tdim, 0),
-                                    mapping="contravariant",
+                                    reference, f, entity=(reference.tdim, 0), mapping="contravariant"
                                 )
                             )
-
+                            f = (
+                                x[1] ** k
+                                * x[0] ** (i - 1)
+                                * (1 - x[0])
+                                * x[2] ** (j - 2)
+                                * (j - 1 - j * x[2]),
+                                0,
+                                x[1] ** k
+                                * x[2] ** (j - 1)
+                                * (1 - x[2])
+                                * x[0] ** (i - 2)
+                                * (i * x[0] - i + 1),
+                            )
+                            dofs.append(
+                                IntegralAgainst(
+                                    reference, f, entity=(reference.tdim, 0), mapping="contravariant"
+                                                )
+                            )
+                            if k in [0, 2]:
+                                f = (
+                                    0, x[0] ** k
+                                    * x[1] ** (i - 1)
+                                    * (1 - x[1])
+                                    * x[2] ** (j - 2)
+                                    * (j - 1 - j * x[2]),
+                                    x[0] ** k
+                                    * x[2] ** (j - 1)
+                                    * (1 - x[2])
+                                    * x[1] ** (i - 2)
+                                    * (i * x[1] - i + 1),
+                                )
+                                dofs.append(
+                                    IntegralAgainst(
+                                        reference,
+                                        f,
+                                        entity=(reference.tdim, 0),
+                                        mapping="contravariant",
+                                    )
+                                )
+        elif reference.name == "prism":
+            pol=prism_polynomial_set_1d(3, order - 3)
+            for pl in pol:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*(1-x[0]-x[1])*x[2]*(1-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))             
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+            for y in range(order-2):
+                for z in range(order-2):
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0]-x[1])*x[2]*(1-x[2]),0])*pol[y*(y+1)//2*(order-2)+z]).curl(),entity=(3,0),mapping="contravariant"))
+            for i in range((order-1) * (order-2)//2):
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]])*pol[i*(order  - 2)]).curl(),entity=(3,0),mapping="contravariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*(1-x[2])])*pol[i*(order  - 2)]).curl(),entity=(3,0),mapping="contravariant"))
+            pol=prism_polynomial_set_1d(3, order - 1)
+            for pl in pol:
+                dofs.append(IntegralAgainst(reference,pl.grad(3),entity=(3,0),mapping="contravariant"))                           
+        
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
 
@@ -629,23 +735,23 @@ class TNTdiv(CiarletElement):
 
     @property
     def lagrange_subdegree(self) -> int:
-        return self.order
+        return self.order # this needs fixing
 
     @property
     def lagrange_superdegree(self) -> int | None:
-        return self.order + 1
+        return self.order + 1  # this needs fixing
 
     @property
     def polynomial_subdegree(self) -> int:
-        return self.order
+        return self.order  # this needs fixing
 
     @property
     def polynomial_superdegree(self) -> int | None:
-        return self.order * self.reference.tdim + 1
+        return self.order * self.reference.tdim + 1 # this needs fixing
 
     names = ["tiniest tensor Hdiv", "TNTdiv"]
-    references = ["quadrilateral", "hexahedron"]
-    min_order = 1
+    references = ["interval", "triangle", "quadrilateral", "tetrahedron", "hexahedron", "prism", "pyramid"]
+    min_order = 0
     continuity = "H(div)"
     value_type = "vector"
-    last_updated = "2025.10"
+    last_updated = "2026.1"

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -238,34 +238,23 @@ class TNTcurl(CiarletElement):
             poly += Hcurl_polynomials(reference.tdim,reference.tdim,order)
             if reference.name == "pyramid":
                 pol=pyramid_polynomial_set_1d(3, order)
-#                print("NN",2*order+1,pol[2*order+1],ScalarFunction(pol[2*order+1]).grad(3))        
                 poly.append(ScalarFunction(pol[2*order+1]).grad(3))
                 if order>1:
-#                    print("OO",order*(order+1)+1,pol[order*(order+1)+1],ScalarFunction(pol[order*(order+1)+1]).grad(3))        
                     poly.append(ScalarFunction(pol[order*(order+1)+1]).grad(3))
-                    for ii in range(order-1):
-#                        print("AA",ii,-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii),pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)],ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]).grad(3))
-                        poly.append(ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]).grad(3))
-                    for ii in range(order-2):
-#                        print("BB",ii,-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii),pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)],ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]).grad(3))                   
-                        poly.append(ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]).grad(3))
-                        for jj in range(ii+1):
-#                            print("CC",ii,jj,3*order+1+ii*order+jj,pol[3*order+1+ii*order+jj],ScalarFunction(pol[3*order+1+ii*order+jj]).grad(3))                   
-                            poly.append(ScalarFunction(pol[3*order+1+ii*order+jj]).grad(3))
-                    for ii in range(order-1):
-                        for jj in range(ii+1):
-#                            print("DD",ii,jj,pol[order-1-ii+jj+(1+ii)*(order+1)],"AAA",VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)])                   
-                            poly.append(VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)]) 
+                for ii in range(order-2):
+                    poly.append(ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]).grad(3))
+                    for jj in range(ii+1):
+                        poly.append(ScalarFunction(pol[3*order+1+ii*order+jj]).grad(3))
+                for ii in range(order-1):
+                    poly.append(ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]).grad(3))
+                    for jj in range(ii+1):
+                        poly.append(VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)]) 
                 pol=polynomial_set_vector(3,3,0)
                 if order>1:
                     poly.append(pol[0]*x[0]**(order-1)*x[1]/(1-x[2]))  # modified from Cockburn & Fu
                     poly.append(pol[1]*x[0]*x[1]**(order-1)/(1-x[2]))  # modified from Cockburn & Fu
                 poly.append(pol[2]*x[0]*x[1]/(1-x[2]))       # modified from Cockburn & Fu
-#                poly.append(pol[2]*x[0]*x[1]**order/(1-x[2]))
-#                poly.append(pol[2]*x[0]**order*x[1]/(1-x[2]))
-#                for pl in pol[max(4-2*order,0):]:
-#                    print("EE",(x[0]*x[1]**order/(1-x[2])*pl/100))
-#                    poly.append(x[0]*x[1]**order/(1-x[2])*pl/100) 
+
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
@@ -450,6 +439,7 @@ class TNTcurl(CiarletElement):
         elif reference.name == "pyramid":
             symmetricpyramid=0 # 0 or 1
             pol=polynomial_set_1d(3, order - 4)
+            for pl in pol:
                 dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
                 dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetericpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
             for pl in pol[-(order-3)*(order-2)//2:]:           
@@ -458,17 +448,7 @@ class TNTcurl(CiarletElement):
             pol=polynomial_set_1d(3, order - 5)
             for pl in pol:
                dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
-
-#            for pl in pol:
-#                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
-#                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-#            for pl in pol[-(order-3)*(order-2)//2:]:           
-#                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[1]*x[0]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-#                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*x[1]*x[2]*(1-x[1]-x[2]),x[0]*x[1]*x[2]*(1-x[1]-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-#            pol=polynomial_set_1d(3, order - 5)
-#            for pl in pol:
-#               dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
-
+        print(poly)
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
 
@@ -525,20 +505,14 @@ class TNTdiv(CiarletElement):
             poly += Hdiv_polynomials(reference.tdim,reference.tdim,order)
             if reference.name == "pyramid":
                 pol=pyramid_polynomial_set_1d(3, order)
-                if order>1:
-                    for ii in range(order-1):
-                        for jj in range(ii+1):
-                            poly.append((VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)]).curl()) 
+                for ii in range(order-1):
+                    for jj in range(ii+1):
+                        poly.append((VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)]).curl()) 
                 pol=polynomial_set_vector(3,3,0)
                 if order>1:
                     poly.append((pol[0]*x[0]**(order-1)*x[1]/(1-x[2])).curl())  # modified from Cockburn & Fu
                     poly.append((pol[1]*x[1]**(order-1)*x[0]/(1-x[2])).curl())  # modified from Cockburn & Fu
                 poly.append((pol[2]*x[0]*x[1]/(1-x[2])).curl())       # modified from Cockburn & Fu
-#                poly.append(pol[2]*x[0]*x[1]**order/(1-x[2]))
-#                poly.append(pol[2]*x[0]**order*x[1]/(1-x[2]))
-#                for pl in pol[max(4-2*order,0):]:
-#                    print("EE",(x[0]*x[1]**order/(1-x[2])*pl/100))
-#                    poly.append(x[0]*x[1]**order/(1-x[2])*pl/100) 
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
@@ -581,13 +555,18 @@ class TNTdiv(CiarletElement):
         if reference.tdim == 3:
             dofs += make_integral_moment_dofs(
                 reference,
-                faces={"triangle": (NormalIntegralMoment, Lagrange, order - 1, {"variant": variant}), "quadrilateral": (NormalIntegralMoment, Q, order - 1, {"variant": variant})}
+                facets={"triangle": (NormalIntegralMoment, Lagrange, order - 1, {"variant": variant}), "quadrilateral": (NormalIntegralMoment, Q, order - 1, {"variant": variant})}
             )
-        elif reference.tdim == 2: # rotated 1-Form
+        elif reference.tdim == 2 : # for 2D: rotated 1-Form
             dofs += make_integral_moment_dofs(
                 reference,
                 facets=(NormalIntegralMoment, Q, order - 1, {"variant": variant})
             )
+        elif reference.tdim ==1 : # for 2D: rotated 1-Form
+            dofs += make_integral_moment_dofs(
+                reference,
+                edges=(TangentIntegralMoment, Q, order - 1, {"variant": variant})) # For 2D: this should be interpreted as rotated for now!          
+        
         if reference.name in ["triangle"]: # rotated 1-Form
             face_moments_s = []
             pol=polynomial_set_1d(2, order - 1)
@@ -718,10 +697,9 @@ class TNTdiv(CiarletElement):
             for i in range((order-1) * (order-2)//2):
                 dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]])*pol[i*(order  - 2)]).curl(),entity=(3,0),mapping="contravariant"))
                 dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*(1-x[2])])*pol[i*(order  - 2)]).curl(),entity=(3,0),mapping="contravariant"))
-            pol=prism_polynomial_set_1d(3, order - 1)
-            for pl in pol:
+            for pl in prism_polynomial_set_1d(3, order - 1)[1:]:
                 dofs.append(IntegralAgainst(reference,pl.grad(3),entity=(3,0),mapping="contravariant"))                           
-        
+
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
 

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -20,7 +20,7 @@ from symfem.functionals import (
 )
 from symfem.functions import FunctionInput, ScalarFunction, VectorFunction
 from symfem.moments import make_integral_moment_dofs
-from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector, polynomial_set_1d, prism_polynomial_set_1d, pyramid_polynomial_set_1d
+from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector, polynomial_set_1d, polynomial_set_vector, prism_polynomial_set_1d, pyramid_polynomial_set_1d
 from symfem.references import NonDefaultReferenceError, Reference
 from symfem.symbols import t, x
 

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -2,6 +2,9 @@
 
 These elements' definitions appear in https://doi.org/10.1090/S0025-5718-2013-02729-9
 (Cockburn, Qiu, 2013)
+
+Prism and Pyramid modified after https://doi.org/10.1137/16M1073352
+(Cockburn, Fu, 2017)
 """
 
 import typing
@@ -20,7 +23,7 @@ from symfem.functionals import (
 )
 from symfem.functions import FunctionInput, ScalarFunction, VectorFunction
 from symfem.moments import make_integral_moment_dofs
-from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector, polynomial_set_1d, polynomial_set_vector, prism_polynomial_set_1d, pyramid_polynomial_set_1d
+from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector, polynomial_set_1d, polynomial_set_vector, prism_polynomial_set_1d, prism_polynomial_set_vector, pyramid_polynomial_set_1d, Hcurl_polynomials
 from symfem.references import NonDefaultReferenceError, Reference
 from symfem.symbols import t, x
 
@@ -73,7 +76,7 @@ class TNT(CiarletElement):
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        if reference.name in ["interval","triangle","tetrahedron","pyramid"]:
+        if reference.name in ["interval", "triangle", "tetrahedron", "pyramid"]:
             poly += polynomial_set_1d(reference.tdim, order)
             if reference.name == "pyramid":
                 pol=pyramid_polynomial_set_1d(3, order)
@@ -86,7 +89,7 @@ class TNT(CiarletElement):
                         for jj in range(ii+1):
                             poly.append(pol[3*order+1+ii*order+jj])
                     poly.append(pol[order*(order+1)+1])
-        elif reference.name in ["quadrilateral","hexahedron"]:
+        elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_1d(reference.tdim, order - 1)
             if reference.tdim == 2:
                 for i in range(2):
@@ -107,68 +110,57 @@ class TNT(CiarletElement):
                             poly.append(f0 * variables[1] * b(order, x[i]))
         elif reference.name == "prism":
             poly += prism_polynomial_set_1d(3, order - 1)
-            pol=polynomial_set_1d(2, 1)  # P_1(x[0],x[1])*x[2]**order
-            for ii in range(len(pol)):
-                poly.append(x[2]**order*pol[ii])
+            for pl in polynomial_set_1d(2, 1)[:2*order-1]: # P_1(x[0],x[1])*x[2]**order
+                poly.append(x[2]**order*pl)
             for i in range(order+1):  # P~_order(x[0],x[1])*{1,x[2]}
                 poly.append(x[0]**i*x[1]**(order-i))
-                if order>1:
-                    poly.append(x[0]**i*x[1]**(order-i)*x[2])
+                poly.append(x[0]**i*x[1]**(order-i)*x[2])
 
         dofs: ListOfFunctionals = []
         for i, v in enumerate(reference.vertices):
             dofs.append(PointEvaluation(reference, v, entity=(0, i)))
 
-        pol=polynomial_set_1d(1, order-1)
-        for edge_n,ii in product(range(reference.sub_entity_count(1)),range(1,order)): # skip 0th order as it falls in the kernel of the gradient
-                dofs.append(IntegralAgainst(reference, pol[ii].grad(1)[0], entity=(1, edge_n), mapping="identity")) 
+        for edge_n,pl in product(range(reference.sub_entity_count(1)),polynomial_set_1d(1, order-1)[1:]): # skip 0th order as it falls in the kernel of the gradient
+                dofs.append(IntegralAgainst(reference, pl.grad(1)[0], entity=(1, edge_n), mapping="identity")) 
 
-        if reference.name in ["triangle","tetrahedron"]:
-            pol=polynomial_set_1d(2, order-3)
-            for face_n,ii in product(range(reference.sub_entity_count(2)),range(len(pol))):
+        if reference.name in ["triangle", "tetrahedron"]:
+            for face_n,pl in product(range(reference.sub_entity_count(2)),polynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity")
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity")
                 )
-        elif reference.name in ["quadrilateral","hexahedron"]:
-            pol=quolynomial_set_1d(2, order-3)
-            for face_n,ii in product(range(reference.sub_entity_count(2)),range(len(pol))):
+        elif reference.name in ["quadrilateral", "hexahedron"]:
+            for face_n,pl in product(range(reference.sub_entity_count(2)),quolynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity")
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity")
                 ) 
         elif reference.name == "prism":
-            pol=polynomial_set_1d(2, order-3)
-            for face_n,ii in product([0,4],range(len(pol))):
+            for face_n,pl in product([0,4],polynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
                 )
-            pol=quolynomial_set_1d(2, order-3)
-            for face_n,ii in product(range(1,4),range(len(pol))):
+            for face_n,pl in product(range(1,4),quolynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity")
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity")
                 ) 
         elif reference.name == "pyramid":
-            pol=quolynomial_set_1d(2, order-3)
-            for ii in range(len(pol)):
+            for pl in quolynomial_set_1d(2, order-3):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pol[ii]).grad(2)), entity=(2, 0), mapping="identity")
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2)), entity=(2, 0), mapping="identity")
                 ) 
-            pol=polynomial_set_1d(2, order-3)
-            for face_n,ii in product(range(1,5),range(len(pol))):
+            for face_n,pl in product(range(1,5),polynomial_set_1d(2, order-3)):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pol[ii]).grad(2)), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2)), entity=(2, face_n), mapping="identity") # does this also work on slanted surfaces of tetrahedron and pyramid?
                 )
                     
         if reference.name == "tetrahedron":
-            pol=polynomial_set_1d(3, order-4)
-            for ii in range(len(pol)):
+            for ii in polynomial_set_1d(3, order-4):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[1]-x[2])*pol[ii]).grad(3)),entity=(3, 0), mapping="identity")
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[1]-x[2])*pl).grad(3)),entity=(3, 0), mapping="identity")
                 )
         elif reference.name == "hexahedron":
-            pol=quolynomial_set_1d(3, order-3)
-            for ii in range(len(pol)):
+            for pl in quolynomial_set_1d(3, order-3):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*pol[ii]).grad(3)),entity=(3, 0), mapping="identity")
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*pl).grad(3)),entity=(3, 0), mapping="identity")
                 )
         elif reference.name == "prism":
             pol=prism_polynomial_set_1d(3, order-3)
@@ -177,10 +169,9 @@ class TNT(CiarletElement):
                     IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*pol[i+j*(order-1)*(order-2)//2]).grad(3)),entity=(3, 0), mapping="identity")
                 )
         elif reference.name == "pyramid":
-            pol=polynomial_set_1d(3, order-5)
-            for ii in range(len(pol)):
+            for pl in polynomial_set_1d(3, order-5):
                 dofs.append(
-                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pol[ii]).grad(3)),entity=(3, 0), mapping="identity")
+                    IntegralAgainst(reference, VectorFunction.div(ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3)),entity=(3, 0), mapping="identity")
                 )
 
         super().__init__(reference, order, poly, dofs, reference.tdim, 1)
@@ -196,7 +187,7 @@ class TNT(CiarletElement):
 
     @property
     def lagrange_subdegree(self) -> int:
-        if self.reference.name in ["interval","triangle","tetrahedron"]:
+        if self.reference.name in ["interval", "triangle", "tetrahedron"]:
             return self.order
         else:
             return self.order - 1
@@ -211,7 +202,7 @@ class TNT(CiarletElement):
 
     @property
     def polynomial_superdegree(self) -> int | None:
-        if self.reference.name in ["interval","triangle","tetrahedron"]:
+        if self.reference.name in ["interval", "triangle", "tetrahedron"]:
             return self.order
         else:
             return max((self.order - 1) * self.reference.tdim, (self.order - 1) + self.reference.tdim)
@@ -239,19 +230,20 @@ class TNTcurl(CiarletElement):
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        if reference.name in ["interval","triangle","tetrahedron"]:
-            poly += polynomial_set_vector(reference.tdim, reference.tdim, order)
-        elif reference.name in ["quadrilateral","hexahedron"]:
-            poly += quolynomial_set_vector(reference.tdim, reference.tdim, order)
+        if reference.name in ["interval", "triangle", "tetrahedron"]:
+            poly += polynomial_set_vector(reference.tdim, reference.tdim, order-1)
+            poly += Hcurl_polynomials(reference.tdim,reference.tdim,order)
+        elif reference.name in ["quadrilateral", "hexahedron"]:
+            poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
                 for ii in product([0, 1], repeat=2):
-                    if sum(ii) != 0:
+                    if sum(ii) != 0 and (order!=1 or sum(ii)!=2):
                         poly.append(
                             tuple(
                                 sympy.S(j).expand()
                                 for j in [
-                                    p(order, ii[0] * x[0]) * b(order + 1, ii[1] * x[1]),
-                                    -b(order + 1, ii[0] * x[0]) * p(order, ii[1] * x[1]),
+                                    p(order - 1, ii[0] * x[0]) * b(order, ii[1] * x[1]),
+                                    -b(order, ii[0] * x[0]) * p(order - 1, ii[1] * x[1]),
                                 ]
                             )
                         )
@@ -263,8 +255,8 @@ class TNTcurl(CiarletElement):
                             tuple(
                                 sympy.S(j).expand()
                                 for j in [
-                                    b(order + 1, ii[0] * t[0]) * p(order, ii[1] * t[1]),
-                                    p(order, ii[0] * t[0]) * b(order + 1, ii[1] * t[1]),
+                                    b(order, ii[0] * t[0]) * p(order - 1, ii[1] * t[1]),
+                                    p(order - 1, ii[0] * t[0]) * b(order , ii[1] * t[1]),
                                 ]
                             )
                         )
@@ -286,50 +278,96 @@ class TNTcurl(CiarletElement):
                         )
                         poly.append(pc)
         elif reference.name == "prism":
-            None
+            poly += prism_polynomial_set_vector(reference.tdim, reference.tdim, order-1)
+            for i in range(order):
+                poly.append(VectorFunction([x[1],-x[0],0])*x[0]**i*x[1]**(order-i-1))
+                poly.append(VectorFunction([x[1],-x[0],0])*x[0]**i*x[1]**(order-i-1)*x[2])
+            for i in range(order+1):  
+                poly.append(VectorFunction([0,0,x[0]**i*x[1]**(order-i)]).curl().cross(VectorFunction([x[0],x[1],x[2]]))*x[2]**(order-1))
+                poly.append(ScalarFunction(x[0]**i*x[1]**(order-i)*x[2]).grad(3)) # P~_order(x[0],x[1])*x[2]
+            if order > 1:
+                # P_1(x[0],x[1])*x[2]**order
+                for pl in polynomial_set_1d(2, 1)[1:]:
+                    poly.append(ScalarFunction(x[2]**order*pl).grad(3))
+                poly.append(VectorFunction([x[1],-x[0],0])*x[2]**order)
+            print(reference.name,order,poly)
+            
+                    
         elif reference.name == "pyramid":
             None
 
+            poly += prism_polynomial_set_1d(3, order - 1)
+                    
         dofs: ListOfFunctionals = []
-        dofs += make_integral_moment_dofs(
-            reference,
-            edges=(TangentIntegralMoment, Q, order, {"variant": variant}),
-        )
+        dofs += make_integral_moment_dofs(reference, edges=(TangentIntegralMoment, Q, order - 1, {"variant": variant}))
 
         # Face moments
-        face_moments = []
-        for ii in product(range(order + 1), repeat=2):
-            if sum(ii) > 0:
-                f = x[0] ** ii[0] * x[1] ** ii[1]
-                grad_f = ScalarFunction(f).grad(2)
-                grad_f2 = VectorFunction((grad_f[1], -grad_f[0])).subs(x[:2], tuple(t[:2]))
-                face_moments.append(grad_f2)
-
-        for i in range(2, order + 1):
-            for j in range(2, order + 1):
-                face_moments.append(
-                    VectorFunction(
-                        (
-                            t[1] ** (j - 1) * (1 - t[1]) * t[0] ** (i - 2) * (i * t[0] - i + 1),
-                            -(t[0] ** (i - 1)) * (1 - t[0]) * t[1] ** (j - 2) * (j - 1 - j * t[1]),
-                        )
-                    )
-                )
-        if reference.tdim == 2:
-            for f in face_moments:
-                dofs.append(IntegralAgainst(reference, f, entity=(2, 0), mapping="covariant"))
-        elif reference.tdim == 3:
-            for face_n in range(6):
-                for f in face_moments:
-                    dofs.append(
-                        IntegralAgainst(reference, f, entity=(2, face_n), mapping="covariant")
-                    )
-
+        if reference.name in ["triangle", "tetrahedron", "prism", "pyramid"]:
+            face_moments_s = []
+            pol=polynomial_set_1d(2, order - 1)
+            for pl in pol[1:]:
+                face_moments_s.append(pl.curl())
+            pol=polynomial_set_1d(2, order - 3)
+            for pl in pol:
+                face_moments_s.append(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).grad(2))
+        if reference.name in ["quadrilateral", "hexahedron", "prism", "pyramid"]:
+            face_moments_q = []
+            pol=quolynomial_set_1d(2, order - 1)
+            for pl in pol[1:]:
+                face_moments_q.append(pl.curl())
+            pol=quolynomial_set_1d(2, order - 3)
+            for pl in pol:
+                face_moments_q.append(ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).grad(2))
+        if reference.name == "triangle":
+            for f in face_moments_s:
+                dofs.append(IntegralAgainst(reference, f, entity=(2,0), mapping="covariant"))
+        elif reference.name == "quadrilateral":
+            for f in face_moments_q:
+                dofs.append(IntegralAgainst(reference, f, entity=(2,0), mapping="covariant"))
+        elif reference.name == "tetrahedron":
+            for f in product(face_moments_s, range(4)):
+                dofs.append(IntegralAgainst(reference, f[0], entity=(2, f[1]), mapping="covariant"))
+        elif reference.name == "hexahedron":
+            for f in product(face_moments_q, range(6)):
+                dofs.append(IntegralAgainst(reference, f[0], entity=(2, f[1]), mapping="covariant"))
+        elif reference.name == "prism":
+            for f in product(face_moments_s, [0,4]):
+                dofs.append(IntegralAgainst(reference, f[0], entity=(2, f[1]), mapping="covariant"))
+            for f in product(face_moments_q, range(1,4)):
+                dofs.append(IntegralAgainst(reference, f[0], entity=(2, f[1]), mapping="covariant"))
+        elif reference.name == "pyramid":
+            for f in face_moments_q:
+                dofs.append(IntegralAgainst(reference, entity=(2, f), mapping="covariant"))
+            for f in product(face_moments_s, range(1,5)):
+                dofs.append(IntegralAgainst(reference, f[0], entity=(2, f[1]), mapping="covariant"))
+            
         # Interior Moments
-        if reference.tdim == 3:
-            for i in range(1, order):
-                for j in range(1, order):
-                    for k in range(order + 1):
+        if reference.name == "tetrahedron":
+            pol=polynomial_set_1d(3, order - 3)
+            for f in pol:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*x[2]*(1-x[0]-x[1]-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1]-x[2])])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+            for f in pol[-(order-2)*(order-1)//2:]:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[1]-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+            pol=polynomial_set_1d(3, order - 4)
+            for f in pol:
+                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[1]-x[2])*f).grad(3),entity=(3,0),mapping="covariant"))
+        elif reference.name == "hexahedron":
+            pol=quolynomial_set_1d(3, order - 3)
+            for f in pol:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))             
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))                
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1]*(1-x[1])* x[2]*(1-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* (1-x[1])*x[2]*(1-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*f).grad(3),entity=(3,0),mapping="covariant"))                
+        elif reference.name == "hexahedronn":
+            for i in range(1, order - 1):
+                for j in range(1, order - 1):
+                    for k in range(order):
                         f = (x[0] ** k * x[1] ** i * (1 - x[1]) * x[2] ** j * (1 - x[2]), 0, 0)
                         dofs.append(
                             IntegralAgainst(
@@ -361,9 +399,9 @@ class TNTcurl(CiarletElement):
                                 )
                             )
 
-            for i in range(2, order + 1):
-                for j in range(2, order + 1):
-                    for k in range(2, order + 1):
+            for i in range(2, order):
+                for j in range(2, order):
+                    for k in range(2, order):
                         f = x[0] ** (i - 1) * x[0] ** i
                         f *= x[1] ** (j - 1) * x[1] ** j
                         f *= x[2] ** (k - 1) * x[2] ** k
@@ -371,6 +409,15 @@ class TNTcurl(CiarletElement):
                         dofs.append(
                             IntegralAgainst(reference, grad_f, entity=(3, 0), mapping="covariant")
                         )
+        elif reference.name == "prism":
+            pol=prism_polynomial_set_1d(3, order - 3)
+            for f in pol:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*(1-x[0]-x[1])*x[2]*(1-x[2]),0,0])*f).curl().curl(),entity=(3,0),mapping="covariant"))             
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0]-x[1])*x[2]*(1-x[2]),0])*f).curl().curl(),entity=(3,0),mapping="covariant"))             
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*(1-x[2])])*f).curl().curl(),entity=(3,0),mapping="covariant"))
+#                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*f).grad(3),entity=(3,0),mapping="covariant"))   
 
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
@@ -385,22 +432,22 @@ class TNTcurl(CiarletElement):
 
     @property
     def lagrange_subdegree(self) -> int:
-        return self.order
+        return self.order - 1
 
     @property
     def lagrange_superdegree(self) -> int | None:
-        return self.order + 1
-
-    @property
-    def polynomial_subdegree(self) -> int:
         return self.order
 
     @property
+    def polynomial_subdegree(self) -> int:
+        return self.order - 1
+
+    @property
     def polynomial_superdegree(self) -> int | None:
-        return self.order * self.reference.tdim + 1
+        return (self.order - 1) * self.reference.tdim + 1
 
     names = ["tiniest tensor Hcurl", "TNTcurl"]
-    references = ["quadrilateral", "hexahedron"]
+    references = ["interval", "triangle", "quadrilateral", "tetrahedron", "hexahedron", "prism", "pyramid"]
     min_order = 1
     continuity = "H(curl)"
     value_type = "vector"
@@ -496,7 +543,43 @@ class TNTdiv(CiarletElement):
                             x[2] ** k
                             * x[1] ** (j - 1)
                             * (1 - x[1])
-                            * x[0] ** (i - 2)
+                            * x[0] ** (i - 2)"""TiNiest Tensor product (TNT) elements.
+
+These elements' definitions appear in https://doi.org/10.1090/S0025-5718-2013-02729-9
+(Cockburn, Qiu, 2013)
+"""
+
+import typing
+from itertools import product
+
+import sympy
+
+from symfem.elements.q import Q
+from symfem.finite_element import CiarletElement
+from symfem.functionals import (
+    IntegralAgainst,
+    ListOfFunctionals,
+    NormalIntegralMoment,
+    PointEvaluation,
+    TangentIntegralMoment,
+)
+from symfem.functions import FunctionInput, ScalarFunction, VectorFunction
+from symfem.moments import make_integral_moment_dofs
+from symfem.polynomials import orthogonal_basis, quolynomial_set_1d, quolynomial_set_vector, polynomial_set_1d, polynomial_set_vector, prism_polynomial_set_1d, pyramid_polynomial_set_1d
+from symfem.references import NonDefaultReferenceError, Reference
+from symfem.symbols import t, x
+
+__all__ = ["p", "b", "TNT", "TNTcurl", "TNTdiv"]
+
+
+def p(k: int, v: sympy.core.symbol.Symbol) -> ScalarFunction:
+    """Return the kth Legendre polynomial.
+
+    Args:
+        k: k
+        v: The variable to use
+
+
                             * (i * x[0] - i + 1),
                             0,
                         )
@@ -525,8 +608,7 @@ class TNTdiv(CiarletElement):
                         )
                         if k in [0, 2]:
                             f = (
-                                0,
-                                x[0] ** k
+                                0, x[0] ** k
                                 * x[1] ** (i - 1)
                                 * (1 - x[1])
                                 * x[2] ** (j - 2)

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -228,7 +228,7 @@ class TNTcurl(CiarletElement):
             order: The polynomial order
             variant: The variant of the element
         """
-        order+=1
+#        order+=1
         if reference.vertices != reference.reference_vertices:
             raise NonDefaultReferenceError()
 
@@ -369,60 +369,17 @@ class TNTcurl(CiarletElement):
         elif reference.name == "hexahedron":
             pol=quolynomial_set_1d(3, order - 3)
             for pl in pol:
+                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))                
                 dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))             
                 dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
                 dofs.append(IntegralAgainst(reference,(VectorFunction([(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))                
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1]*(1-x[1])* x[2]*(1-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* (1-x[1])*x[2]*(1-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))                
-        elif reference.name == "hexahedronn":
-            for i in range(1, order - 1):
-                for j in range(1, order - 1):
-                    for k in range(order):
-                        f = (x[0] ** k * x[1] ** i * (1 - x[1]) * x[2] ** j * (1 - x[2]), 0, 0)
-                        dofs.append(
-                            IntegralAgainst(
-                                reference,
-                                VectorFunction(f).curl().curl(),
-                                entity=(3, 0),
-                                mapping="covariant",
-                            )
-                        )
-
-                        f = (0, x[1] ** k * x[0] ** i * (1 - x[0]) * x[2] ** j * (1 - x[2]), 0)
-                        dofs.append(
-                            IntegralAgainst(
-                                reference,
-                                VectorFunction(f).curl().curl(),
-                                entity=(3, 0),
-                                mapping="covariant",
-                            )
-                        )
-
-                        if k in [0, 2]:
-                            f = (0, 0, x[2] ** k * x[0] ** i * (1 - x[0]) * x[1] ** j * (1 - x[1]))
-                            dofs.append(
-                                IntegralAgainst(
-                                    reference,
-                                    VectorFunction(f).curl().curl(),
-                                    entity=(3, 0),
-                                    mapping="covariant",
-                                )
-                            )
-
-            for i in range(2, order):
-                for j in range(2, order):
-                    for k in range(2, order):
-                        f = x[0] ** (i - 1) * x[0] ** i
-                        f *= x[1] ** (j - 1) * x[1] ** j
-                        f *= x[2] ** (k - 1) * x[2] ** k
-                        grad_f = ScalarFunction(f).grad(3)
-                        dofs.append(
-                            IntegralAgainst(reference, grad_f, entity=(3, 0), mapping="covariant")
-                        )
+            for i in range(order-2):
+                for j in range(order-2):
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*pol[i * (order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1]*(1-x[1])* x[2]*(1-x[2]),0])*pol[i * (order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* (1-x[1])*x[2]*(1-x[2]),0])*pol[i * (order-2)*(order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*pol[i * (order-2)*(order-2)+j]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])])*pol[i * (order-2)*(order-2)+j*(order-2)+order-3]).curl().curl(),entity=(3,0),mapping="covariant"))
         elif reference.name == "prism":
             pol=prism_polynomial_set_1d(3, order - 3)
             for pl in pol:
@@ -448,7 +405,9 @@ class TNTcurl(CiarletElement):
             pol=polynomial_set_1d(3, order - 5)
             for pl in pol:
                dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
-        print(poly)
+
+        print(reference.name, order, order-1, poly)
+#        order-=1
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
 
@@ -495,7 +454,7 @@ class TNTdiv(CiarletElement):
             order: The polynomial order
             variant: The variant of the element
         """
-        order+=1
+#        order+=1
         if reference.vertices != reference.reference_vertices:
             raise NonDefaultReferenceError()
 
@@ -522,8 +481,8 @@ class TNTdiv(CiarletElement):
                             tuple(
                                 sympy.S(j).expand()
                                 for j in [
-                                    b(order, ii[0] * x[0]) * p(order, ii[1] * x[1]),
-                                    p(order - 1, ii[0] * x[0]) * b(order + 1, ii[1] * x[1]),
+                                    b(order, ii[0] * x[0]) * p(order - 1, ii[1] * x[1]),
+                                    p(order - 1, ii[0] * x[0]) * b(order, ii[1] * x[1]),
                                 ]
                             )
                         )
@@ -567,31 +526,20 @@ class TNTdiv(CiarletElement):
                 reference,
                 edges=(TangentIntegralMoment, Q, order - 1, {"variant": variant})) # For 2D: this should be interpreted as rotated for now!          
         
-        if reference.name in ["triangle"]: # rotated 1-Form
-            face_moments_s = []
-            pol=polynomial_set_1d(2, order - 1)
-            for pl in pol[1:]:
-                face_moments_s.append(pl.grad(2))
-            pol=polynomial_set_1d(2, order - 3)
-            for pl in pol:
-                face_moments_s.append(ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).curl()) # modified from Cockburn & Qiu : grad -> curl to avoid singular Vandermonde matrix 
-            for f in face_moments_s:
-                dofs.append(IntegralAgainst(reference, f, entity=(2,0), mapping="contravariant"))                    
-        elif reference.name in ["tetrahedron", "pyramid"]:
-            for pl in polynomial_set_1d(reference.tdim,order-1)[1:]:
-                dofs.append(
-                    IntegralAgainst(
-                        reference, pl.grad(reference.tdim), entity=(reference.tdim, 0), mapping="contravariant"
-                    )
-                )
-            if reference.name == "tetrahedron":
+        if reference.name in ["triangle", "tetrahedron", "pyramid"]: # rotated 1-Form
+            for pl in polynomial_set_1d(reference.tdim, order - 1)[1:]:
+                dofs.append(IntegralAgainst(reference, pl.grad(reference.tdim), entity=(reference.tdim,0), mapping="contravariant"))                    
+            if reference.name == "triangle":
+                for pl in polynomial_set_1d(2, order - 3):
+                    dofs.append(IntegralAgainst(reference, ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*pl).curl(), entity=(2,0), mapping="contravariant"))                    
+            elif reference.name == "tetrahedron":
                 pol=polynomial_set_1d(3, order - 3)
                 for pl in pol:
                     dofs.append(IntegralAgainst(reference,(VectorFunction([x[1]*x[2]*(1-x[0]-x[1]-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))
                     dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
                 for pl in pol[-(order-2)*(order-1)//2:]:
                     dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[1]-x[2]),0])*pl).curl(),entity=(3,0),mapping="contravariant"))
-            else:
+            elif reference.name == "pyramid":
                 pol=polynomial_set_1d(3, order - 4)
                 symmetricpyramid=0 # 0 or 1
                 for pl in pol:
@@ -601,91 +549,24 @@ class TNTdiv(CiarletElement):
                     dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetericpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
                     dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),x[0]*x[1]*x[2]*(1-x[1]-x[2]),0])*pl).curl(),entity=(3,0),mapping="contravariant"))
         elif reference.name in ["quadrilateral", "hexahedron"]:
-            for ii in product(range(order), repeat=reference.tdim):
-                if sum(ii) > 0:
-                    if reference.tdim == 2:
-                        f = x[0] ** ii[0] * x[1] ** ii[1]
-                    else:
-                        f = x[0] ** ii[0] * x[1] ** ii[1] * x[2] ** ii[2]
-                    grad_f = ScalarFunction(f).grad(reference.tdim)
-                    dofs.append(
-                        IntegralAgainst(
-                            reference, grad_f, entity=(reference.tdim, 0), mapping="contravariant"
-                        )
-                    )
-            if reference.tdim == 2:  # rotated 1-Form
-                for i in range(2, order):
-                    for j in range(2, order):
-                        f = (
-                            x[0] ** (i - 1) * (1 - x[0]) * x[1] ** (j - 2) * (j - 1 - j * x[1]),
-                            x[1] ** (j - 1) * (1 - x[1]) * x[0] ** (i - 2) * (i * x[0] - i + 1),
-                        )
-                        dofs.append(
-                            IntegralAgainst(
-                                reference, f, entity=(reference.tdim, 0), mapping="contravariant"
-                            )
-                        )
-            if reference.tdim == 3:
-                for i in range(2, order):
-                    for j in range(2, order):
-                        for k in range(order):
-                            f = (
-                                x[2] ** k
-                                * x[0] ** (i - 1)
-                                * (1 - x[0])
-                                * x[2] ** (j - 2)
-                                * (j - 1 - j * x[1]),
-                                x[2] ** k
-                                * x[1] ** (j - 1)
-                                * (1 - x[1])
-                                * x[0] ** (i - 2)
-                                * (i * x[0] - i + 1),
-                                0,
-                            )
-                            dofs.append(
-                                IntegralAgainst(
-                                    reference, f, entity=(reference.tdim, 0), mapping="contravariant"
-                                )
-                            )
-                            f = (
-                                x[1] ** k
-                                * x[0] ** (i - 1)
-                                * (1 - x[0])
-                                * x[2] ** (j - 2)
-                                * (j - 1 - j * x[2]),
-                                0,
-                                x[1] ** k
-                                * x[2] ** (j - 1)
-                                * (1 - x[2])
-                                * x[0] ** (i - 2)
-                                * (i * x[0] - i + 1),
-                            )
-                            dofs.append(
-                                IntegralAgainst(
-                                    reference, f, entity=(reference.tdim, 0), mapping="contravariant"
-                                                )
-                            )
-                            if k in [0, 2]:
-                                f = (
-                                    0, x[0] ** k
-                                    * x[1] ** (i - 1)
-                                    * (1 - x[1])
-                                    * x[2] ** (j - 2)
-                                    * (j - 1 - j * x[2]),
-                                    x[0] ** k
-                                    * x[2] ** (j - 1)
-                                    * (1 - x[2])
-                                    * x[1] ** (i - 2)
-                                    * (i * x[1] - i + 1),
-                                )
-                                dofs.append(
-                                    IntegralAgainst(
-                                        reference,
-                                        f,
-                                        entity=(reference.tdim, 0),
-                                        mapping="contravariant",
-                                    )
-                                )
+            for pl in quolynomial_set_1d(reference.tdim, order - 1)[1:]:
+                dofs.append(IntegralAgainst(reference, pl.grad(reference.tdim), entity=(reference.tdim, 0), mapping="contravariant"))
+            if reference.name == "quadrilateral":  # rotated 1-Form
+                for pl in quolynomial_set_1d(2, order - 3):
+                    dofs.append(IntegralAgainst(reference, ScalarFunction(x[0]*(1-x[0])*x[1]*(1-x[1])*pl).curl(), entity=(2,0), mapping="contravariant"))  # modified from Cockburn & Qiu : grad -> curl to avoid singular Vandermonde matrix 
+            elif reference.name == "hexahedron":
+                pol=quolynomial_set_1d(3, order - 3)
+                for pl in pol:
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))             
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([x[0]*(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([(1-x[0])* x[1]*(1-x[1])*x[2]*(1-x[2]),0,0])*pl).curl(),entity=(3,0),mapping="contravariant"))                
+                for i in range(order-2):
+                    for j in range(order-2):
+                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1] *x[2]*(1-x[2]),0])*pol[i * (order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))
+                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* x[1]*(1-x[1])* x[2]*(1-x[2]),0])*pol[i * (order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))
+                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*(1-x[0])* (1-x[1])*x[2]*(1-x[2]),0])*pol[i * (order-2)*(order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))
+                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]])*pol[i * (order-2)*(order-2)+j]).curl(),entity=(3,0),mapping="contravariant"))
+                        dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*(1-x[0])*x[1]*(1-x[1])*x[2]*(1-x[2])])*pol[i * (order-2)*(order-2)+j*(order-2)+order-3]).curl(),entity=(3,0),mapping="contravariant"))
         elif reference.name == "prism":
             pol=prism_polynomial_set_1d(3, order - 3)
             for pl in pol:
@@ -699,7 +580,8 @@ class TNTdiv(CiarletElement):
                 dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1])*(1-x[2])])*pol[i*(order  - 2)]).curl(),entity=(3,0),mapping="contravariant"))
             for pl in prism_polynomial_set_1d(3, order - 1)[1:]:
                 dofs.append(IntegralAgainst(reference,pl.grad(3),entity=(3,0),mapping="contravariant"))                           
-
+#        print(reference.name, order, poly)
+#        order-=1
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
 

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -254,14 +254,17 @@ class TNTcurl(CiarletElement):
                         if ii!=0 or jj!=0 or kk!=order:
                             poly.append(ScalarFunction(pol[-(kk+1)*(kk+2)*(2*kk+3)//6+ii*(kk+1)+jj]).grad(3))
             for kk in range(order):
-                poly.append(VectorFunction([1,0,x[0]/(1-x[2])])*pol[kk+1])
-                poly.append(VectorFunction([0,1,x[1]/(1-x[2])])*pol[(kk+1)*(order+1)])
+#                poly.append(VectorFunction([1,0,x[0]/(1-x[2])])*pol[kk+1])
+#                poly.append(VectorFunction([0,1,x[1]/(1-x[2])])*pol[(kk+1)*(order+1)])
                 for ii in range(order-kk):
                     for jj in range(order-kk):
                         poly.append(VectorFunction([1-x[2],0,x[0]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj])
                         poly.append(VectorFunction([0,1-x[2],x[1]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj])                    
-            for kk in range(order-1):
-                poly.append(VectorFunction([-pol[(kk+1)*(order+1)+kk+2],pol[(kk+2)*(order+1)+kk+1],0]))
+            for kk in range(min(order,2)):
+                poly.append(VectorFunction([1,0,x[0]/(1-x[2])])*pol[kk+1])
+                poly.append(VectorFunction([0,1,x[1]/(1-x[2])])*pol[(kk+1)*(order+1)])
+            if order>1:
+                poly.append(VectorFunction([-pol[(order+1)+2],pol[2*(order+1)+1],0]))
 
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
@@ -420,18 +423,19 @@ class TNTcurl(CiarletElement):
         elif reference.name == "pyramid":
             symmetricpyramid=0 # 0 or 1
             pol=pyramid_polynomial_set_1d(3, order -3)
-            for pl in pol:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-            for z in range(order-2):
-                for y in range(order-z-2):
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*pol[-(order-z-3)*(order-z-2)*(2*order-2*z-5)//6-y*(order-z-2)-1]).curl().curl(),entity=(3,0),mapping="covariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2]),((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])])*pol[-(order-z-3)*(order-z-2)*(2*order-2*z-5)//6-y-1]).curl().curl(),entity=(3,0),mapping="covariant"))
+            for zz in range(order-2):
+              for yy in range(order-zz-3):
+                for xx in range(order-zz-2):
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**(2-min(xx+1,yy)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*(1-x[2])**(2-min(xx+1,yy)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl().curl(),entity=(3,0),mapping="covariant")) 
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**2*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)+order-2]).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**(2-min(1,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)]).curl().curl(),entity=(3,0),mapping="covariant"))
+            for pl in pol[:(order-2)*(order-2)]:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**2*pl).curl().curl(),entity=(3,0),mapping="covariant"))
             pol=pyramid_polynomial_set_1d(3, order -4)
             for pl in pol:
-               dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))
+               dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*(1+x[2])*(1+x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))
         order-=1
-#        print("tntcurl",reference.name,order)
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
 
@@ -489,15 +493,16 @@ class TNTdiv(CiarletElement):
         if reference.name == "pyramid":
             pol=pyramid_polynomial_set_1d(3, order)
             for kk in range(order):
-                poly.append((VectorFunction([1,0,x[0]/(1-x[2])])*pol[kk+1]).curl())
-                poly.append((VectorFunction([0,1,x[1]/(1-x[2])])*pol[(kk+1)*(order+1)]).curl())
                 for ii in range(order-kk):
                     for jj in range(order-kk):
                         poly.append((VectorFunction([1-x[2],0,x[0]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj]).curl())
                         poly.append((VectorFunction([0,1-x[2],x[1]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj]).curl())
                         poly.append((VectorFunction([x[0],x[1],x[2]-1])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj]))
-            for kk in range(order-1):
-                poly.append(VectorFunction([-pol[(kk+1)*(order+1)+kk+2],pol[(kk+2)*(order+1)+kk+1],0]).curl())
+            for kk in range(min(order,2)):
+                poly.append((VectorFunction([1,0,x[0]/(1-x[2])])*pol[kk+1]).curl())
+                poly.append((VectorFunction([0,1,x[1]/(1-x[2])])*pol[(kk+1)*(order+1)]).curl())
+            if order>1:
+                poly.append(VectorFunction([-pol[(order+1)+2],pol[2*(order+1)+1],0]).curl())
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
@@ -562,16 +567,17 @@ class TNTdiv(CiarletElement):
         elif reference.name == "pyramid":
             for pl in pyramid_polynomial_set_1d(3, order-1)[1:]:
                 dofs.append(IntegralAgainst(reference, ScalarFunction(pl).grad(3), entity=(3,0), mapping="contravariant"))                  
-            pol=pyramid_polynomial_set_1d(3, order-3)
             symmetricpyramid=0 # 0 or 1
-            for pl in pol:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
-            for z in range(order-2):
-                for y in range(order-z-2):
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*pol[-(order-z-3)*(order-z-2)*(2*order-2*z-5)//6-y*(order-z-2)-1]).curl(),entity=(3,0),mapping="contravariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2]),((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])])*pol[-(order-z-3)*(order-z-2)*(2*order-2*z-5)//6-y-1]).curl(),entity=(3,0),mapping="contravariant"))
-            pol=pyramid_polynomial_set_1d(3, order -4)
+            pol=pyramid_polynomial_set_1d(3, order -3)
+            for zz in range(order-2):
+              for yy in range(order-zz-3):
+                for xx in range(order-zz-2):
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**(2-min(xx+1,yy)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*(1-x[2])**(2-min(xx+1,yy)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl(),entity=(3,0),mapping="contravariant")) 
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**2*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)+order-2]).curl(),entity=(3,0),mapping="contravariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**(2-min(1,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)]).curl().curl(),entity=(3,0),mapping="contravariant"))
+            for pl in pol[:(order-2)*(order-2)]:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**2*pl).curl(),entity=(3,0),mapping="contravariant"))
         elif reference.name in ["quadrilateral", "hexahedron"]:
             for pl in quolynomial_set_1d(reference.tdim, order - 1)[1:]:
                 dofs.append(IntegralAgainst(reference, pl.grad(reference.tdim), entity=(reference.tdim, 0), mapping="contravariant"))

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -5,6 +5,7 @@ These elements' definitions appear in https://doi.org/10.1090/S0025-5718-2013-02
 
 Prism and Pyramid modified after https://doi.org/10.1137/16M1073352
 (Cockburn, Fu, 2017)
+and Nigam
 """
 
 import typing
@@ -78,19 +79,21 @@ class TNT(CiarletElement):
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        if reference.name in ["interval", "triangle", "tetrahedron", "pyramid"]:
+        if reference.name in ["interval", "triangle", "tetrahedron"]:
             poly += polynomial_set_1d(reference.tdim, order)
-            if reference.name == "pyramid":
-                pol=pyramid_polynomial_set_1d(3, order)
-                for ii in range(order-1):
-                    poly.append(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]) # x y/(1-w) P~_order-2(x,z) modified from Cockburn & Fu
-                poly.append(pol[2*order+1])
-                if order>1:
-                    for ii in range(order-2):
-                        poly.append(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]) # x y z/(1-w) P~_order-3(y,z) modified from Cockburn & Fu
-                        for jj in range(ii+1):
-                            poly.append(pol[3*order+1+ii*order+jj])
-                    poly.append(pol[order*(order+1)+1])
+        elif reference.name == "pyramid":
+            pol=pyramid_polynomial_set_1d(3, order)
+            for kk in range(order+1):
+                for ii in range(kk+1):
+                    if ii<2:
+                        jmax=kk+1
+                    else:
+                        if ii<kk:
+                            jmax=kk
+                        else:
+                            jmax=2
+                    for jj in range(jmax):
+                        poly.append(pol[-(kk+1)*(kk+2)*(2*kk+3)//6+ii*(kk+1)+jj])
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_1d(reference.tdim, order - 1)
             if reference.tdim == 2:
@@ -171,7 +174,7 @@ class TNT(CiarletElement):
                     IntegralAgainst(reference, ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*pol[i+j*(order-1)*(order-2)//2]).grad(3).div(),entity=(3, 0), mapping="identity")
                 )
         elif reference.name == "pyramid":
-            for pl in polynomial_set_1d(3, order-5):
+            for pl in pyramid_polynomial_set_1d(3, order -4):
                 dofs.append(
                     IntegralAgainst(reference, ScalarFunction(x[0]*x[1]*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3).div(),entity=(3, 0), mapping="identity")
                 )
@@ -233,27 +236,32 @@ class TNTcurl(CiarletElement):
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        if reference.name in ["interval", "triangle", "tetrahedron", "pyramid"]:
+        if reference.name in ["interval", "triangle", "tetrahedron"]:
             poly += polynomial_set_vector(reference.tdim, reference.tdim, order-1)
             poly += Hcurl_polynomials(reference.tdim,reference.tdim,order)
-            if reference.name == "pyramid":
-                pol=pyramid_polynomial_set_1d(3, order)
-                poly.append(ScalarFunction(pol[2*order+1]).grad(3))
-                if order>1:
-                    poly.append(ScalarFunction(pol[order*(order+1)+1]).grad(3))
-                for ii in range(order-2):
-                    poly.append(ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+2*(order-ii)]).grad(3))
-                    for jj in range(ii+1):
-                        poly.append(ScalarFunction(pol[3*order+1+ii*order+jj]).grad(3))
-                for ii in range(order-1):
-                    poly.append(ScalarFunction(pol[-(order-ii+1)*(order-ii+2)*(2*(order-ii)+3)//6+(order-ii)*(order-ii)]).grad(3))
-                    for jj in range(ii+1):
-                        poly.append(VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)]) 
-                pol=polynomial_set_vector(3,3,0)
-                if order>1:
-                    poly.append(pol[0]*x[0]**(order-1)*x[1]/(1-x[2]))  # modified from Cockburn & Fu
-                    poly.append(pol[1]*x[0]*x[1]**(order-1)/(1-x[2]))  # modified from Cockburn & Fu
-                poly.append(pol[2]*x[0]*x[1]/(1-x[2]))       # modified from Cockburn & Fu
+        elif reference.name == "pyramid":
+            pol=pyramid_polynomial_set_1d(3, order)
+            for kk in range(order+1):
+                for ii in range(kk+1):
+                    if ii<2:
+                        jmax=kk+1
+                    else:
+                        if ii<kk:
+                            jmax=kk
+                        else:
+                            jmax=2
+                    for jj in range(jmax):
+                        if ii!=0 or jj!=0 or kk!=order:
+                            poly.append(ScalarFunction(pol[-(kk+1)*(kk+2)*(2*kk+3)//6+ii*(kk+1)+jj]).grad(3))
+            for kk in range(order):
+                poly.append(VectorFunction([1,0,x[0]/(1-x[2])])*pol[kk+1])
+                poly.append(VectorFunction([0,1,x[1]/(1-x[2])])*pol[(kk+1)*(order+1)])
+                for ii in range(order-kk):
+                    for jj in range(order-kk):
+                        poly.append(VectorFunction([1-x[2],0,x[0]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj])
+                        poly.append(VectorFunction([0,1-x[2],x[1]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj])                    
+            for kk in range(order-1):
+                poly.append(VectorFunction([-pol[(kk+1)*(order+1)+kk+2],pol[(kk+2)*(order+1)+kk+1],0]))
 
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
@@ -411,14 +419,15 @@ class TNTcurl(CiarletElement):
                 dofs.append(IntegralAgainst(reference,ScalarFunction(x[0]*x[1]*(1-x[0]-x[1])*x[2]*(1-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))   
         elif reference.name == "pyramid":
             symmetricpyramid=0 # 0 or 1
-            pol=polynomial_set_1d(3, order - 4)
+            pol=pyramid_polynomial_set_1d(3, order -3)
             for pl in pol:
                 dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
                 dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-            for pl in pol[-(order-3)*(order-2)//2:]:           
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0])*pl).curl().curl(),entity=(3,0),mapping="covariant"))
-            pol=polynomial_set_1d(3, order - 5)
+            for z in range(order-2):
+                for y in range(order-z-2):
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*pol[-(order-z-3)*(order-z-2)*(2*order-2*z-5)//6-y*(order-z-2)-1]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2]),((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])])*pol[-(order-z-3)*(order-z-2)*(2*order-2*z-5)//6-y-1]).curl().curl(),entity=(3,0),mapping="covariant"))
+            pol=pyramid_polynomial_set_1d(3, order -4)
             for pl in pol:
                dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))
         order-=1
@@ -474,19 +483,21 @@ class TNTdiv(CiarletElement):
             raise NonDefaultReferenceError()
 
         poly: list[FunctionInput] = []
-        if reference.name in ["interval", "triangle", "tetrahedron", "pyramid"]:
+        if reference.name in ["interval", "triangle", "tetrahedron"]:
             poly += polynomial_set_vector(reference.tdim, reference.tdim, order-1)
             poly += Hdiv_polynomials(reference.tdim,reference.tdim,order)
-            if reference.name == "pyramid":
-                pol=pyramid_polynomial_set_1d(3, order)
-                for ii in range(order-1):
-                    for jj in range(ii+1):
-                        poly.append((VectorFunction([x[1],-x[0],0])*pol[order-1-ii+jj+(1+ii)*(order+1)]).curl()) 
-                pol=polynomial_set_vector(3,3,0)
-                if order>1:
-                    poly.append((pol[0]*x[0]**(order-1)*x[1]/(1-x[2])).curl())  # modified from Cockburn & Fu
-                    poly.append((pol[1]*x[1]**(order-1)*x[0]/(1-x[2])).curl())  # modified from Cockburn & Fu
-                poly.append((pol[2]*x[0]*x[1]/(1-x[2])).curl())       # modified from Cockburn & Fu
+        if reference.name == "pyramid":
+            pol=pyramid_polynomial_set_1d(3, order)
+            for kk in range(order):
+                poly.append((VectorFunction([1,0,x[0]/(1-x[2])])*pol[kk+1]).curl())
+                poly.append((VectorFunction([0,1,x[1]/(1-x[2])])*pol[(kk+1)*(order+1)]).curl())
+                for ii in range(order-kk):
+                    for jj in range(order-kk):
+                        poly.append((VectorFunction([1-x[2],0,x[0]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj]).curl())
+                        poly.append((VectorFunction([0,1-x[2],x[1]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj]).curl())
+                        poly.append((VectorFunction([x[0],x[1],x[2]-1])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj]))
+            for kk in range(order-1):
+                poly.append(VectorFunction([-pol[(kk+1)*(order+1)+kk+2],pol[(kk+2)*(order+1)+kk+1],0]).curl())
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
@@ -535,7 +546,7 @@ class TNTdiv(CiarletElement):
                 reference,
                 edges=(TangentIntegralMoment, Q, order - 1, {"variant": variant})) # For 2D: this should be interpreted as rotated for now!          
         
-        if reference.name in ["triangle", "tetrahedron", "pyramid"]: # rotated 1-Form
+        if reference.name in ["triangle", "tetrahedron"]: # rotated 1-Form
             for pl in polynomial_set_1d(reference.tdim, order - 1)[1:]:
                 dofs.append(IntegralAgainst(reference, pl.grad(reference.tdim), entity=(reference.tdim,0), mapping="contravariant"))                    
             if reference.name == "triangle":
@@ -548,15 +559,19 @@ class TNTdiv(CiarletElement):
                     dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,x[0]*x[1]*(1-x[0]-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
                 for pl in pol[-(order-2)*(order-1)//2:]:
                     dofs.append(IntegralAgainst(reference,(VectorFunction([0,x[0]*x[2]*(1-x[0]-x[1]-x[2]),0])*pl).curl(),entity=(3,0),mapping="contravariant"))
-            elif reference.name == "pyramid":
-                pol=polynomial_set_1d(3, order - 4)
-                symmetricpyramid=0 # 0 or 1
-                for pl in pol:
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
-                for pl in pol[-(order-3)*(order-2)//2:]:           
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0])*pl).curl(),entity=(3,0),mapping="contravariant"))
+        elif reference.name == "pyramid":
+            for pl in pyramid_polynomial_set_1d(3, order-1)[1:]:
+                dofs.append(IntegralAgainst(reference, ScalarFunction(pl).grad(3), entity=(3,0), mapping="contravariant"))                  
+            pol=pyramid_polynomial_set_1d(3, order-3)
+            symmetricpyramid=0 # 0 or 1
+            for pl in pol:
+                dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*pl).curl(),entity=(3,0),mapping="contravariant"))
+            for z in range(order-2):
+                for y in range(order-z-2):
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*pol[-(order-z-3)*(order-z-2)*(2*order-2*z-5)//6-y*(order-z-2)-1]).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2]),((1-x[2])*symmetricpyramid+x[1])*((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])])*pol[-(order-z-3)*(order-z-2)*(2*order-2*z-5)//6-y-1]).curl(),entity=(3,0),mapping="contravariant"))
+            pol=pyramid_polynomial_set_1d(3, order -4)
         elif reference.name in ["quadrilateral", "hexahedron"]:
             for pl in quolynomial_set_1d(reference.tdim, order - 1)[1:]:
                 dofs.append(IntegralAgainst(reference, pl.grad(reference.tdim), entity=(reference.tdim, 0), mapping="contravariant"))

--- a/symfem/elements/tnt.py
+++ b/symfem/elements/tnt.py
@@ -260,11 +260,20 @@ class TNTcurl(CiarletElement):
                     for jj in range(order-kk):
                         poly.append(VectorFunction([1-x[2],0,x[0]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj])
                         poly.append(VectorFunction([0,1-x[2],x[1]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj])                    
-            for kk in range(min(order,2)):
-                poly.append(VectorFunction([1,0,x[0]/(1-x[2])])*pol[kk+1])
-                poly.append(VectorFunction([0,1,x[1]/(1-x[2])])*pol[(kk+1)*(order+1)])
-            if order>1:
-                poly.append(VectorFunction([-pol[(order+1)+2],pol[2*(order+1)+1],0]))
+#            for kk in range(min(order,2)):
+#                poly.append(VectorFunction([1,0,x[0]/(1-x[2])])*pol[order-1-kk+1])
+#                poly.append(VectorFunction([0,1,x[1]/(1-x[2])])*pol[(order-1-kk+1)*(order+1)]*1000000)
+#            for kk in range(1):
+#                poly.append(VectorFunction([1,0,x[0]/(1-x[2])])*pol[order-1-kk+1])
+#                poly.append(VectorFunction([0,1,x[1]/(1-x[2])])*pol[(order-1-kk+1)*(order+1)])
+
+            for kk in range(0,order,max(order-1,1)):
+                poly.append(VectorFunction([1,0,x[0]/(1-x[2])])*pol[order-1-kk+1])
+                poly.append(VectorFunction([0,1,x[1]/(1-x[2])])*pol[(order-1-kk+1)*(order+1)])
+            for kk in range(max(order-2,0),order-1):
+                poly.append(VectorFunction([-pol[(kk+1)*(order+1)+kk+2],pol[(kk+2)*(order+1)+kk+1],0]))
+
+#                poly.append(VectorFunction([-pol[(order+1)+2],pol[2*(order+1)+1],0]))
 
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
@@ -426,15 +435,15 @@ class TNTcurl(CiarletElement):
             for zz in range(order-2):
               for yy in range(order-zz-3):
                 for xx in range(order-zz-2):
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**(2-min(xx+1,yy)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl().curl(),entity=(3,0),mapping="covariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*(1-x[2])**(2-min(xx+1,yy)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl().curl(),entity=(3,0),mapping="covariant")) 
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**2*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)+order-2]).curl().curl(),entity=(3,0),mapping="covariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**(2-min(1,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**-(-1-min(xx,yy+1)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl().curl(),entity=(3,0),mapping="covariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*(1-x[2])**(-1-min(xx,yy+1)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl().curl(),entity=(3,0),mapping="covariant"))
+                for xx in range(0,order-zz-2,order-zz-3):
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**-(-1-min(xx,yy+1)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)+xx]).curl().curl(),entity=(3,0),mapping="covariant"))
             for pl in pol[:(order-2)*(order-2)]:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**2*pl).curl().curl(),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**-2*pl).curl().curl(),entity=(3,0),mapping="covariant"))
             pol=pyramid_polynomial_set_1d(3, order -4)
             for pl in pol:
-               dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*(1+x[2])*(1+x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))
+                dofs.append(IntegralAgainst(reference,ScalarFunction(((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])*(1+x[2])*(1+x[2])*pl).grad(3),entity=(3,0),mapping="covariant"))
         order-=1
         super().__init__(reference, order, poly, dofs, reference.tdim, reference.tdim)
         self.variant = variant
@@ -498,11 +507,11 @@ class TNTdiv(CiarletElement):
                         poly.append((VectorFunction([1-x[2],0,x[0]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj]).curl())
                         poly.append((VectorFunction([0,1-x[2],x[1]])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj]).curl())
                         poly.append((VectorFunction([x[0],x[1],x[2]-1])*pol[-(kk+max(ii,jj)+2)*(kk+max(ii,jj)+3)*(2*(kk+max(ii,jj))+5)//6+ii*(kk+max(ii,jj)+2)+jj]))
-            for kk in range(min(order,2)):
-                poly.append((VectorFunction([1,0,x[0]/(1-x[2])])*pol[kk+1]).curl())
-                poly.append((VectorFunction([0,1,x[1]/(1-x[2])])*pol[(kk+1)*(order+1)]).curl())
-            if order>1:
-                poly.append(VectorFunction([-pol[(order+1)+2],pol[2*(order+1)+1],0]).curl())
+            for kk in range(0,order,max(order-1,1)):
+                poly.append((VectorFunction([1,0,x[0]/(1-x[2])])*pol[order-1-kk+1]).curl())
+                poly.append((VectorFunction([0,1,x[1]/(1-x[2])])*pol[(order-1-kk+1)*(order+1)]).curl())
+            for kk in range(max(order-2,0),order-1):
+                poly.append(VectorFunction([-pol[(kk+1)*(order+1)+kk+2],pol[(kk+2)*(order+1)+kk+1],0]).curl())
         elif reference.name in ["quadrilateral", "hexahedron"]:
             poly += quolynomial_set_vector(reference.tdim, reference.tdim, order-1)
             if reference.tdim == 2:
@@ -572,12 +581,12 @@ class TNTdiv(CiarletElement):
             for zz in range(order-2):
               for yy in range(order-zz-3):
                 for xx in range(order-zz-2):
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**(2-min(xx+1,yy)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl(),entity=(3,0),mapping="contravariant"))
-                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*(1-x[2])**(2-min(xx+1,yy)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl(),entity=(3,0),mapping="contravariant")) 
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**2*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)+order-2]).curl(),entity=(3,0),mapping="contravariant"))
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**(2-min(1,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)]).curl().curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),0,-symmetricpyramid*(1+x[1]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**-(-1-min(xx,yy+1)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl(),entity=(3,0),mapping="contravariant"))
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2]),0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*x[2]*(1-x[1]-x[2])])*(1-x[2])**(-1-min(xx,yy+1)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+xx*(order-zz-2)+yy]).curl(),entity=(3,0),mapping="contravariant"))
+                for xx in range(0,order-zz-2,order-zz-3):
+                    dofs.append(IntegralAgainst(reference,(VectorFunction([0,((1-x[2])*symmetricpyramid+x[0])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2]),-symmetricpyramid*(1+x[0]-x[2])*x[2]*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**-(-1-min(xx,yy+1)+min(xx,yy))*pol[-(order-zz-2)*(order-zz-1)*(2*order-2*zz-3)//6+yy*(order-zz-2)+xx]).curl(),entity=(3,0),mapping="contravariant"))
             for pl in pol[:(order-2)*(order-2)]:
-                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**2*pl).curl(),entity=(3,0),mapping="contravariant"))
+                dofs.append(IntegralAgainst(reference,(VectorFunction([0,0,((1-x[2])*symmetricpyramid+x[0])*((1-x[2])*symmetricpyramid+x[1])*(1-x[0]-x[2])*(1-x[1]-x[2])])*(1-x[2])**-2*pl).curl(),entity=(3,0),mapping="contravariant"))
         elif reference.name in ["quadrilateral", "hexahedron"]:
             for pl in quolynomial_set_1d(reference.tdim, order - 1)[1:]:
                 dofs.append(IntegralAgainst(reference, pl.grad(reference.tdim), entity=(reference.tdim, 0), mapping="contravariant"))

--- a/symfem/functions.py
+++ b/symfem/functions.py
@@ -768,7 +768,12 @@ class ScalarFunction(Function):
         Returns:
             The curl
         """
-        raise ValueError("Cannot compute the curl of a scalar-valued function.")
+        return VectorFunction(
+            [
+                self.diff(x[1]), - self.diff(x[0])
+            ]
+        )
+
 
     def norm(self) -> ScalarFunction:
         """Compute the norm of the function.

--- a/symfem/polynomials/polysets.py
+++ b/symfem/polynomials/polysets.py
@@ -112,6 +112,8 @@ def Hcurl_polynomials(
         A set of polynomials
     """
     assert domain_dim == range_dim
+    if domain_dim == 1:
+        return []
     if domain_dim == 2:
         return [
             VectorFunction(

--- a/symfem/polynomials/polysets.py
+++ b/symfem/polynomials/polysets.py
@@ -25,19 +25,18 @@ def polynomial_set_1d(
         return [ScalarFunction(variables[0] ** i) for i in range(order + 1)]
     if dim == 2:
         return [
-            ScalarFunction(variables[0] ** i * variables[1] ** j)
+            ScalarFunction(variables[0] ** i * variables[1] ** (j - i))
             for j in range(order + 1)
-            for i in range(order + 1 - j)
+            for i in range(j + 1)
         ]
     if dim == 3:
         return [
-            ScalarFunction(variables[0] ** i * variables[1] ** j * variables[2] ** k)
+            ScalarFunction(variables[0] ** i * variables[1] ** (j - i) * variables[2] ** (k - j))
             for k in range(order + 1)
-            for j in range(order + 1 - k)
-            for i in range(order + 1 - k - j)
+            for j in range(k + 1)
+            for i in range(j + 1)
         ]
     raise ValueError(f"Unsupported dimension: {dim}")
-
 
 def polynomial_set_vector(
     domain_dim: int, range_dim: int, order: int, variables: AxisVariablesNotSingle = x
@@ -469,12 +468,11 @@ def prism_polynomial_set_1d(
     """
     assert dim == 3
     return [
-        ScalarFunction(variables[0] ** i * variables[1] ** j * variables[2] ** k)
-        for k in range(order + 1)
+        ScalarFunction(variables[0] ** i * variables[1] ** (j - i) * variables[2] ** k)
         for j in range(order + 1)
-        for i in range(order + 1 - j)
+        for i in range(j + 1)
+        for k in range(order + 1)
     ]
-
 
 def prism_polynomial_set_vector(
     domain_dim: int, range_dim: int, order: int, variables: AxisVariablesNotSingle = x

--- a/symfem/polynomials/polysets.py
+++ b/symfem/polynomials/polysets.py
@@ -75,6 +75,8 @@ def Hdiv_polynomials(
         A set of polynomials
     """
     assert domain_dim == range_dim
+    if domain_dim == 1:
+        return []
     if domain_dim == 2:
         return [
             VectorFunction(

--- a/symfem/references.py
+++ b/symfem/references.py
@@ -2189,7 +2189,18 @@ class Pyramid(Reference):
         Returns:
             A lattice of points offset from the edge of the cell
         """
-        raise NotImplementedError()
+        assert self.vertices == self.reference_vertices
+        pts = []
+        for k in range(n + 1):
+            z = sympy.Rational(2 * k + 1, 2 * (n + 1))
+            m = n - k
+            for i in range(m + 1):
+                x = sympy.Rational(2 * i + 1, 2 * (n + 1))
+                for j in range(m + 1):
+                    y = sympy.Rational(2 * j + 1, 2 * (n + 1))
+                    if x + z <= 1 and y + z <= 1:
+                        pts.append((x, y, z))
+        return tuple(pts)
 
     def make_lattice_with_lines(self, n: int) -> LatticeWithLines:
         """Make a lattice of points, and a list of lines connecting them.


### PR DESCRIPTION
Add 1st order 0-Form elements
Add interval, triangle, tetrahedron, prism and pyramid for 0-Forms, modified from Cockburn & Fu
Modified the internal degrees of freedom using integration by parts to Laplacian.
Shifted order of curl for matching with 0-Forms in complex

- There appears to be a problem for 3rd order prism on the backend.

Todo: 
- Hexahedron 1st
- Eliminate curl kernel of 3d elements (tetrahedron already works?)
- Pyramid (visualization is defelement issue)
- Hdiv
- DPC pyramid for inclusion in complex (serendipity type)


