### PR TITLE
skip Basix install for Python 3.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,8 +31,11 @@ jobs:
           path: /home/runner/.cache/symfem
           key: symfem-matrix-cache
       - uses: actions/checkout@v4
-      - run: pip install git+https://github.com/FEniCS/basix.git git+https://github.com/FEniCS/ufl.git
-        name: Install Basix and UFL
+      - run: pip install git+https://github.com/FEniCS/ufl.git
+        name: Install UFL
+      - run: pip install git+https://github.com/FEniCS/basix.git
+        name: Install Basix
+        if: matrix.python-version != '3.10'
       - run: pip install .[test] pytest-xdist
         name: Install Symfem
       - name: Install LaTeΧ
@@ -41,6 +44,10 @@ jobs:
           sudo apt-get install -y texlive-latex-base texlive-latex-extra
       - run: python3 -m pytest --durations=50 test -W error -xvs --has-basix 1
         name: Run unit tests
+        if: matrix.python-version != '3.10'
+      - run: python3 -m pytest --durations=50 test -W error -xvs --has-basix 0
+        name: Run unit tests
+        if: matrix.python-version == '3.10'
       - run: python3 -m pytest demo/test_demos.py -W error
         name: Run demos
       - run: python3 -m pytest scripts/test_scripts.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,10 +31,8 @@ jobs:
           path: /home/runner/.cache/symfem
           key: symfem-matrix-cache
       - uses: actions/checkout@v4
-      - run: pip install git+https://github.com/FEniCS/ufl.git
-        name: Install UFL
-      - run: pip install git+https://github.com/FEniCS/basix.git
-        name: Install Basix
+      - run: pip install git+https://github.com/FEniCS/basix.git git+https://github.com/FEniCS/ufl.git
+        name: Install Basix and UFL
         if: matrix.python-version != '3.10'
       - run: pip install .[test] pytest-xdist
         name: Install Symfem


### PR DESCRIPTION
Basix's minimum Python version is now 3.11